### PR TITLE
Add InscribeSpellEvent

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/events/InscribeSpellEvent.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/events/InscribeSpellEvent.java
@@ -1,0 +1,33 @@
+package io.redspace.ironsspellbooks.api.events;
+
+
+import io.redspace.ironsspellbooks.api.spells.CastSource;
+import io.redspace.ironsspellbooks.api.spells.SchoolType;
+import io.redspace.ironsspellbooks.capabilities.spell.SpellData;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.Cancelable;
+
+/**
+ * InscribeSpellEvent is fired whenever a {@link Player} inscribes a spell into a spellbook.<br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the spell is not inscribed.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/
+public class InscribeSpellEvent extends PlayerEvent {
+    private final SpellData spellData;
+    public InscribeSpellEvent(Player player, SpellData spellData)
+    {
+        super(player);
+        this.spellData = spellData;
+    }
+
+    @Override
+    public boolean isCancelable() { return true; }
+    public SpellData getSpellData() { return this.spellData; }
+}

--- a/src/main/java/io/redspace/ironsspellbooks/gui/inscription_table/InscriptionTableMenu.java
+++ b/src/main/java/io/redspace/ironsspellbooks/gui/inscription_table/InscriptionTableMenu.java
@@ -146,8 +146,8 @@ public class InscriptionTableMenu extends AbstractContainerMenu {
         //Called whenever the client clicks on a button. The ID passed in is the spell slot index or -1. If it is positive, it is to select that slot. If it is negative, it is to inscribe
         if (pId < 0) {
             if (selectedSpellIndex >= 0 && getScrollSlot().getItem().is(ItemRegistry.SCROLL.get())){
-                SpellData scrollData = SpellData.getSpellData(getScrollSlot().getItem());
-                if (MinecraftForge.EVENT_BUS.post(new InscribeSpellEvent(pPlayer, scrollData)))
+                SpellData spellData = SpellData.getSpellData(getScrollSlot().getItem());
+                if (MinecraftForge.EVENT_BUS.post(new InscribeSpellEvent(pPlayer, spellData)))
                     return false;
                 doInscription(selectedSpellIndex);
             }

--- a/src/main/java/io/redspace/ironsspellbooks/gui/inscription_table/InscriptionTableMenu.java
+++ b/src/main/java/io/redspace/ironsspellbooks/gui/inscription_table/InscriptionTableMenu.java
@@ -1,6 +1,7 @@
 package io.redspace.ironsspellbooks.gui.inscription_table;
 
 import io.redspace.ironsspellbooks.IronsSpellbooks;
+import io.redspace.ironsspellbooks.api.events.InscribeSpellEvent;
 import io.redspace.ironsspellbooks.capabilities.spell.SpellData;
 import io.redspace.ironsspellbooks.capabilities.spellbook.SpellBookData;
 import io.redspace.ironsspellbooks.item.Scroll;
@@ -16,6 +17,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.*;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
 
 public class InscriptionTableMenu extends AbstractContainerMenu {
     //    public final InscriptionTableTile blockEntity;
@@ -143,8 +145,12 @@ public class InscriptionTableMenu extends AbstractContainerMenu {
     public boolean clickMenuButton(Player pPlayer, int pId) {
         //Called whenever the client clicks on a button. The ID passed in is the spell slot index or -1. If it is positive, it is to select that slot. If it is negative, it is to inscribe
         if (pId < 0) {
-            if (selectedSpellIndex >= 0 && getScrollSlot().getItem().is(ItemRegistry.SCROLL.get()))
+            if (selectedSpellIndex >= 0 && getScrollSlot().getItem().is(ItemRegistry.SCROLL.get())){
+                SpellData scrollData = SpellData.getSpellData(getScrollSlot().getItem());
+                if (MinecraftForge.EVENT_BUS.post(new InscribeSpellEvent(pPlayer, scrollData)))
+                    return false;
                 doInscription(selectedSpellIndex);
+            }
         } else {
             setSelectedSpell(pId);
         }


### PR DESCRIPTION
This fires when a player tries to inscribe a spell into a spell book. If cancelled the spell will not be inscribed. 

I tested it with
```
@SubscribeEvent
 public static void onInscribeSpell(InscribeSpellEvent inscribeSpellEvent) {
        SpellData spellData = inscribeSpellEvent.getSpellData();
        boolean serverSide = !inscribeSpellEvent.getEntity().level().isClientSide();
        if(serverSide && spellData != null && Objects.equals(spellData.getSpell().getSpellId(), "irons_spellbooks:fireball")) {
            inscribeSpellEvent.setCanceled(true);
        }
    }
```
Which would not let fireball be inscribed into a spellbook, but any other spell works.