### PR TITLE
Added new network method to API

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/network/spells/ServerBoundManaUpdate.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/network/spells/ServerBoundManaUpdate.java
@@ -1,0 +1,12 @@
+package io.redspace.ironsspellbooks.api.network.spells;
+
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.network.ClientboundSyncMana;
+import io.redspace.ironsspellbooks.setup.Messages;
+import net.minecraft.server.level.ServerPlayer;
+
+public class ServerBoundManaUpdate {
+    public ServerBoundManaUpdate(ServerPlayer serverPlayer, MagicData magicData){
+        Messages.sendToPlayer(new ClientboundSyncMana(magicData),serverPlayer);
+    }
+}

--- a/src/main/java/io/redspace/ironsspellbooks/api/util/UpdateClient.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/util/UpdateClient.java
@@ -1,12 +1,15 @@
-package io.redspace.ironsspellbooks.api.network.spells;
+package io.redspace.ironsspellbooks.api.util;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.network.ClientboundSyncMana;
 import io.redspace.ironsspellbooks.setup.Messages;
 import net.minecraft.server.level.ServerPlayer;
 
-public class ServerBoundManaUpdate {
-    public ServerBoundManaUpdate(ServerPlayer serverPlayer, MagicData magicData){
+public class UpdateClient {
+    // More Util updates to be added
+    public static void SendManaUpdate(ServerPlayer serverPlayer, MagicData magicData){
         Messages.sendToPlayer(new ClientboundSyncMana(magicData),serverPlayer);
     }
+
+
 }


### PR DESCRIPTION
Adds a new network method to the API to be used by add-ons to prevent client desync from server when changing mana.


### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
