### PR TITLE
Cancel Spell Casts from server

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/util/UpdateClient.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/util/UpdateClient.java
@@ -2,6 +2,7 @@ package io.redspace.ironsspellbooks.api.util;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.network.ClientboundSyncMana;
+import io.redspace.ironsspellbooks.network.spell.ClientboundOnCastFinished;
 import io.redspace.ironsspellbooks.setup.Messages;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -10,6 +11,10 @@ public class UpdateClient {
     public static void SendManaUpdate(ServerPlayer serverPlayer, MagicData magicData){
         Messages.sendToPlayer(new ClientboundSyncMana(magicData),serverPlayer);
     }
-
+    public static void SendCastCancel(ServerPlayer serverPlayer, MagicData magicData){
+        var spellData = magicData.getCastingSpell();
+        magicData.getCastingSpell().getSpell().onServerCastComplete(serverPlayer.level, spellData.getLevel(), serverPlayer, magicData, true);
+        Messages.sendToPlayersTrackingEntity(new ClientboundOnCastFinished(serverPlayer.getUUID(),magicData.getCastingSpellId(),true),serverPlayer,true);
+    }
 
 }

--- a/src/main/java/io/redspace/ironsspellbooks/spells/test.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/test.java
@@ -1,0 +1,4 @@
+package io.redspace.ironsspellbooks.api.spells;
+@AutoSpellConfig
+public class test extends AbstractSpell {
+}

--- a/src/main/java/io/redspace/ironsspellbooks/spells/test.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/test.java
@@ -1,4 +1,0 @@
-package io.redspace.ironsspellbooks.api.spells;
-@AutoSpellConfig
-public class test extends AbstractSpell {
-}


### PR DESCRIPTION
Adds a new method to UpdateClient class adding a way to cancel spells from the server and relay that information.

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [ X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
