### PR TITLE
Add config option for CAN_BE_CRAFTED (1.19.2)

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/config/DefaultConfig.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/config/DefaultConfig.java
@@ -11,6 +11,7 @@ public class DefaultConfig {
     public int maxLevel = -1;
     public boolean enabled = true;
     public double cooldownInSeconds = -1;
+    public boolean canBeCrafted = true;
 
     public DefaultConfig(Consumer<DefaultConfig> intialize) throws RuntimeException {
         intialize.accept(this);
@@ -42,6 +43,11 @@ public class DefaultConfig {
 
     public DefaultConfig setSchoolResource(ResourceLocation schoolResource) {
         this.schoolResource = schoolResource;
+        return this;
+    }
+
+    public DefaultConfig setCanBeCrafted(boolean canBeCrafted) {
+        this.canBeCrafted = canBeCrafted;
         return this;
     }
 

--- a/src/main/java/io/redspace/ironsspellbooks/api/config/DefaultConfig.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/config/DefaultConfig.java
@@ -11,7 +11,7 @@ public class DefaultConfig {
     public int maxLevel = -1;
     public boolean enabled = true;
     public double cooldownInSeconds = -1;
-    public boolean canBeCrafted = true;
+    public boolean allowCrafting = true;
 
     public DefaultConfig(Consumer<DefaultConfig> intialize) throws RuntimeException {
         intialize.accept(this);
@@ -46,8 +46,8 @@ public class DefaultConfig {
         return this;
     }
 
-    public DefaultConfig setCanBeCrafted(boolean canBeCrafted) {
-        this.canBeCrafted = canBeCrafted;
+    public DefaultConfig setAllowCrafting(boolean allowCrafting) {
+        this.allowCrafting = allowCrafting;
         return this;
     }
 

--- a/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
@@ -594,7 +594,7 @@ public abstract class AbstractSpell {
      * Returns an additional condition for whether this spell can be crafted by a player. This does NOT omit it from the scroll forge entirely
      */
     public boolean canBeCraftedBy(Player player) {
-        return true;
+        return ServerConfigs.getSpellConfig(this).canBeCrafted();
     }
 
     /**

--- a/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
@@ -594,14 +594,14 @@ public abstract class AbstractSpell {
      * Returns an additional condition for whether this spell can be crafted by a player. This does NOT omit it from the scroll forge entirely
      */
     public boolean canBeCraftedBy(Player player) {
-        return ServerConfigs.getSpellConfig(this).canBeCrafted();
+        return true;
     }
 
     /**
      * Returns an additional condition for whether this spell can be crafted in the scroll forge, or whether it will be omitted
      */
     public boolean allowCrafting() {
-        return true;
+        return ServerConfigs.getSpellConfig(this).allowCrafting();
     }
 
     public boolean obfuscateStats(@Nullable Player player) {

--- a/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
+++ b/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
@@ -8,16 +8,10 @@ import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.SpellRarity;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.data.ForgeItemTagsProvider;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.event.config.ModConfigEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.*;
@@ -184,7 +178,7 @@ public class ServerConfigs {
                 BUILDER.define("ManaCostMultiplier", 1d),
                 BUILDER.define("SpellPowerMultiplier", 1d),
                 BUILDER.define("CooldownInSeconds", config.cooldownInSeconds),
-                BUILDER.define("CanBeCrafted", config.canBeCrafted)
+                BUILDER.define("AllowCrafting", config.allowCrafting)
         ));
 
         BUILDER.pop();
@@ -214,7 +208,7 @@ public class ServerConfigs {
         final Supplier<Double> M_MULT;
         final Supplier<Double> P_MULT;
         final Supplier<Double> CS;
-        final Supplier<Boolean> CAN_BE_CRAFTED;
+        final Supplier<Boolean> ALLOW_CRAFTING;
 
         SpellConfigParameters(
                 DefaultConfig defaultConfig,
@@ -225,7 +219,7 @@ public class ServerConfigs {
                 Supplier<Double> M_MULT,
                 Supplier<Double> P_MULT,
                 Supplier<Double> CS,
-                Supplier<Boolean> CAN_BE_CRAFTED) {
+                Supplier<Boolean> ALLOW_CRAFTING) {
             this.ENABLED = ENABLED;
             this.SCHOOL = SCHOOL;
             this.MAX_LEVEL = MAX_LEVEL;
@@ -233,7 +227,7 @@ public class ServerConfigs {
             this.M_MULT = M_MULT;
             this.P_MULT = P_MULT;
             this.CS = CS;
-            this.CAN_BE_CRAFTED = CAN_BE_CRAFTED;
+            this.ALLOW_CRAFTING = ALLOW_CRAFTING;
             this.ACTUAL_SCHOOL = LazyOptional.of(() -> {
                 if (ResourceLocation.isValidResourceLocation(SCHOOL.get())) {
                     var school = SchoolRegistry.getSchool(new ResourceLocation(SCHOOL.get()));
@@ -270,8 +264,8 @@ public class ServerConfigs {
             return (int) (CS.get() * 20);
         }
 
-        public boolean canBeCrafted() {
-            return CAN_BE_CRAFTED.get();
+        public boolean allowCrafting() {
+            return ALLOW_CRAFTING.get();
         }
 
         public SchoolType school() {

--- a/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
+++ b/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
@@ -28,7 +28,7 @@ public class ServerConfigs {
 
     private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
     public static final ForgeConfigSpec SPEC;
-    public static final SpellConfigParameters DEFAULT_CONFIG = new SpellConfigParameters(null, () -> true, SchoolRegistry.EVOCATION_RESOURCE::toString, () -> 10, () -> SpellRarity.COMMON, () -> 1d, () -> 1d, () -> 10d);
+    public static final SpellConfigParameters DEFAULT_CONFIG = new SpellConfigParameters(null, () -> true, SchoolRegistry.EVOCATION_RESOURCE::toString, () -> 10, () -> SpellRarity.COMMON, () -> 1d, () -> 1d, () -> 10d, () -> true);
     public static final ForgeConfigSpec.ConfigValue<Boolean> SWORDS_CONSUME_MANA;
     public static final ForgeConfigSpec.ConfigValue<Double> SWORDS_CD_MULTIPLIER;
     public static final ForgeConfigSpec.ConfigValue<Boolean> CAN_ATTACK_OWN_SUMMONS;
@@ -183,7 +183,8 @@ public class ServerConfigs {
                 BUILDER.defineEnum("MinRarity", config.minRarity),
                 BUILDER.define("ManaCostMultiplier", 1d),
                 BUILDER.define("SpellPowerMultiplier", 1d),
-                BUILDER.define("CooldownInSeconds", config.cooldownInSeconds)
+                BUILDER.define("CooldownInSeconds", config.cooldownInSeconds),
+                BUILDER.define("CanBeCrafted", config.canBeCrafted)
         ));
 
         BUILDER.pop();
@@ -213,6 +214,7 @@ public class ServerConfigs {
         final Supplier<Double> M_MULT;
         final Supplier<Double> P_MULT;
         final Supplier<Double> CS;
+        final Supplier<Boolean> CAN_BE_CRAFTED;
 
         SpellConfigParameters(
                 DefaultConfig defaultConfig,
@@ -222,7 +224,8 @@ public class ServerConfigs {
                 Supplier<SpellRarity> MIN_RARITY,
                 Supplier<Double> M_MULT,
                 Supplier<Double> P_MULT,
-                Supplier<Double> CS) {
+                Supplier<Double> CS,
+                Supplier<Boolean> CAN_BE_CRAFTED) {
             this.ENABLED = ENABLED;
             this.SCHOOL = SCHOOL;
             this.MAX_LEVEL = MAX_LEVEL;
@@ -230,6 +233,7 @@ public class ServerConfigs {
             this.M_MULT = M_MULT;
             this.P_MULT = P_MULT;
             this.CS = CS;
+            this.CAN_BE_CRAFTED = CAN_BE_CRAFTED;
             this.ACTUAL_SCHOOL = LazyOptional.of(() -> {
                 if (ResourceLocation.isValidResourceLocation(SCHOOL.get())) {
                     var school = SchoolRegistry.getSchool(new ResourceLocation(SCHOOL.get()));
@@ -264,6 +268,10 @@ public class ServerConfigs {
 
         public int cooldownInTicks() {
             return (int) (CS.get() * 20);
+        }
+
+        public boolean canBeCrafted() {
+            return CAN_BE_CRAFTED.get();
         }
 
         public SchoolType school() {

--- a/src/main/java/io/redspace/ironsspellbooks/config/SpellConfigParameters.java
+++ b/src/main/java/io/redspace/ironsspellbooks/config/SpellConfigParameters.java
@@ -9,10 +9,11 @@ public class SpellConfigParameters {
     public final double POWER_MULTIPLIER;
     public final double COOLDOWN_IN_SECONDS;
     public final boolean ENABLED;
+    public final boolean CAN_BE_CRAFTED;
 
     //Not implemented:
 
-    public SpellConfigParameters(boolean ENABLED, int MAX_LEVEL, SpellRarity MIN_RARITY, double POWER_MULTIPLIER, double MANA_MULTIPLIER, double COOLDOWN_IN_SECONDS) {
+    public SpellConfigParameters(boolean ENABLED, int MAX_LEVEL, SpellRarity MIN_RARITY, double POWER_MULTIPLIER, double MANA_MULTIPLIER, double COOLDOWN_IN_SECONDS, boolean CAN_BE_CRAFTED) {
         //IronsSpellbooks.LOGGER.debug("CFG: SpellConfigParameters");
         this.MAX_LEVEL = MAX_LEVEL;
         this.MIN_RARITY = MIN_RARITY;
@@ -20,5 +21,6 @@ public class SpellConfigParameters {
         this.MANA_MULTIPLIER = MANA_MULTIPLIER;
         this.POWER_MULTIPLIER = POWER_MULTIPLIER;
         this.COOLDOWN_IN_SECONDS = COOLDOWN_IN_SECONDS;
+        this.CAN_BE_CRAFTED = CAN_BE_CRAFTED;
     }
 }

--- a/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/AbstractEldritchSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/AbstractEldritchSpell.java
@@ -36,7 +36,7 @@ public abstract class AbstractEldritchSpell extends AbstractSpell {
 
     @Override
     public boolean canBeCraftedBy(Player player) {
-        return isLearned(player);
+        return super.canBeCraftedBy(player) || isLearned(player);
     }
 
     @Override

--- a/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/AbstractEldritchSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/AbstractEldritchSpell.java
@@ -36,7 +36,7 @@ public abstract class AbstractEldritchSpell extends AbstractSpell {
 
     @Override
     public boolean canBeCraftedBy(Player player) {
-        return super.canBeCraftedBy(player) || isLearned(player);
+        return isLearned(player);
     }
 
     @Override


### PR DESCRIPTION
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.

This change should allow modpack creators to disable a spell from being crafted in a Scroll Forge.
It has been tested in a Forge 47.2.18 instance.
![image](https://github.com/iron431/irons-spells-n-spellbooks/assets/95097230/ea9521c6-2dd8-49be-9aba-b0d6cdacabee)