### PR TITLE
Allow other mods' animations in AnimationHolder

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/util/AnimationHolder.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/util/AnimationHolder.java
@@ -14,7 +14,7 @@ public class AnimationHolder {
     public final boolean animatesLegs;
 
     public AnimationHolder(String path, boolean playOnce, boolean animatesLegs) {
-        this.playerAnimation = IronsSpellbooks.id(path);
+        this.playerAnimation = path.contains(":") ? new ResourceLocation(path) : IronsSpellbooks.id(path);
         this.geckoAnimation = new AnimationBuilder().addAnimation(playerAnimation.getPath(), playOnce ? ILoopType.EDefaultLoopTypes.PLAY_ONCE : ILoopType.EDefaultLoopTypes.HOLD_ON_LAST_FRAME);
         this.isPass = false;
         this.animatesLegs = animatesLegs;


### PR DESCRIPTION
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.

This fix should allow addon creators to add their own custom spell animations without using the Iron's Spells namespace.