### PR TITLE
Fix black hole spell position in creative inventory

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/registry/SpellRegistry.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/registry/SpellRegistry.java
@@ -103,6 +103,7 @@ public class SpellRegistry {
     public static final RegistryObject<AbstractSpell> RECALL_SPELL = registerSpell(new RecallSpell());
     public static final RegistryObject<AbstractSpell> PORTAL_SPELL = registerSpell(new PortalSpell());
     public static final RegistryObject<AbstractSpell> ECHOING_STRIKES_SPELL = registerSpell(new EchoingStrikesSpell());
+    public static final RegistryObject<AbstractSpell> BLACK_HOLE_SPELL = registerSpell(new BlackHoleSpell());
 
     // EVOCATION
     public static final RegistryObject<AbstractSpell> CHAIN_CREEPER_SPELL = registerSpell(new ChainCreeperSpell());
@@ -181,9 +182,8 @@ public class SpellRegistry {
     public static final RegistryObject<AbstractSpell> STOMP_SPELL = registerSpell(new StompSpell());
     public static final RegistryObject<AbstractSpell> GLUTTONY_SPELL = registerSpell(new GluttonySpell());
 
-    //VOID
+    // ELDRITCH
     public static final RegistryObject<AbstractSpell> ABYSSAL_SHROUD_SPELL = registerSpell(new AbyssalShroudSpell());
-    public static final RegistryObject<AbstractSpell> BLACK_HOLE_SPELL = registerSpell(new BlackHoleSpell());
     public static final RegistryObject<AbstractSpell> SCULK_TENTACLES_SPELL = registerSpell(new SculkTentaclesSpell());
     public static final RegistryObject<AbstractSpell> SONIC_BOOM_SPELL = registerSpell(new SonicBoomSpell());
     public static final RegistryObject<AbstractSpell> PLANAR_SIGHT_SPELL = registerSpell(new PlanarSightSpell());


### PR DESCRIPTION
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.

Fixes #441 . Now the Eldritch scrolls are all in the same group and the same applies for the Ender ones.
![2024-05-23_00 00 11](https://github.com/iron431/irons-spells-n-spellbooks/assets/43759103/376e86ac-c015-4a30-951f-e124232852ea)
