### PR TITLE
Minor fixes in en_us.json

### DIFF
--- a/src/main/resources/assets/irons_spellbooks/lang/en_us.json
+++ b/src/main/resources/assets/irons_spellbooks/lang/en_us.json
@@ -208,7 +208,6 @@
   "item.irons_spellbooks.priest_spawn_egg": "Priest Spawn Egg",
   "item.irons_spellbooks.apothecarist_spawn_egg": "Apothecarist Spawn Egg",
 
-
   "block.irons_spellbooks.inscription_table": "Inscription Table",
   "block.irons_spellbooks.scroll_forge": "Scroll Forge",
   "block.irons_spellbooks.pedestal": "Pedestal",
@@ -282,7 +281,6 @@
   "ui.irons_spellbooks.percent_damage": "%d%% Damage",
   "ui.irons_spellbooks.impact_damage": "%d Impact Damage",
   "ui.irons_spellbooks.aoe_damage": "%d AOE Damage",
-  "ui.irons_spellbooks.percent_damage": "%d%% Damage",
   "ui.irons_spellbooks.aoe_healing": "%d AOE Healing",
   "ui.irons_spellbooks.max_hp_on_kill": "%d Max HP on Kill",
   "ui.irons_spellbooks.slowness_effect": "Slowness %d",
@@ -852,7 +850,7 @@
   "itemGroup.spell_materials_tab": "Iron's Spellbooks Materials",
   "itemGroup.spell_equipment_tab": "Iron's Spellbooks Equipment",
 
-  "advancements.irons_spellbooks.root.title": "Iron's Spells 'n  Spellbooks",
+  "advancements.irons_spellbooks.root.title": "Iron's Spells 'n Spellbooks",
   "advancements.irons_spellbooks.root.description": "There's more than meets the eye to this world...",
   "advancements.irons_spellbooks.make_inscription_table.title": "Quaint Scribe",
   "advancements.irons_spellbooks.make_inscription_table.description": "Craft an Inscription Table",
@@ -871,7 +869,7 @@
   "advancements.irons_spellbooks.spell_book_netherite.title": "Ancient Knowledge",
   "advancements.irons_spellbooks.spell_book_netherite.description": "Restore the Ancient Codex.",
   "advancements.irons_spellbooks.spell_book_dragon.title": "Elder Power",
-  "advancements.irons_spellbooks.spell_book_dragon.description": "Craft the Dragonksin Spell Book.",
+  "advancements.irons_spellbooks.spell_book_dragon.description": "Craft the Dragonskin Spell Book.",
   "advancements.irons_spellbooks.spell_book_evoker.title": "Grimoire of Evokation",
   "advancements.irons_spellbooks.spell_book_evoker.description": "Obtain the unique spell book from the illagers.",
   "advancements.irons_spellbooks.spell_book_rotten.title": "How long's this been here?",


### PR DESCRIPTION
- Unnecessary blank row removed
- Duplicate string removed
- Extra space removed
- Fixed typo

---
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
