### PR TITLE
Updated tetra compat statbars

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/compat/tetra/StatGetterPercentAttribute.java
+++ b/src/main/java/io/redspace/ironsspellbooks/compat/tetra/StatGetterPercentAttribute.java
@@ -7,8 +7,7 @@ import se.mickelus.tetra.gui.stats.getter.StatGetterAttribute;
 
 public class StatGetterPercentAttribute extends StatGetterAttribute {
     public StatGetterPercentAttribute(Attribute attribute) {
-        super(attribute);
-        withOffset(-1);
+        super(attribute, false, false, -1);
     }
 
     @Override


### PR DESCRIPTION
I've got some gradle issues that prevents me from starting up the dev environment for Iron's Spells 'n Spellbooks so I've not tested this 😅, but this should resolve the crash introduced by the latest tetra update!

Resolves #678, resolves mickelus/tetra#863

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
