### PR TITLE
Optimize removal in DamageSources.java

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/damage/DamageSources.java
+++ b/src/main/java/io/redspace/ironsspellbooks/damage/DamageSources.java
@@ -82,7 +82,7 @@ public class DamageSources {
         if (livingEntity.getServer() != null) {
             var tickCount = livingEntity.getServer().getTickCount();
             //help manage memory
-            knockbackImmunes.entrySet().stream().filter(entry -> tickCount - entry.getValue() >= 10).toList().forEach(entry -> knockbackImmunes.remove(entry.getKey()));
+            knockbackImmunes.entrySet().removeIf(entry -> tickCount - entry.getValue() >= 10);
             //enter entity
             knockbackImmunes.put(livingEntity.getUUID(), tickCount);
         }


### PR DESCRIPTION
Just using the `EntrySet#removeIf` function instead of streaming to a list.  Saves a tiny amount of memory, shrug.

Alternately, you could just use a WeakHashMap so you just won't retain the keys on the heap without needing to manually go through them yourself each time.  On the other hand, that would _automatically_ free them up, without giving you the opportunity to save them persistently - if you wanted to do that.  Also, the map is small enough that idk if it matters, but optimization go brrrrr.

You could also index by UUID instead of by the entity itself to be extra sure. I'm not sure what the chances of a UUID collision are, but I'm pretty sure they're basically nonexistent at the scale we're working on.

But yeah your way also works, I just wanted to fix a semantic thing for ya and teach you something cool you can do with the set views.

Cheers!

### Contributor License Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
