### PR TITLE
Support for focus items belonging to multiple schools

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/registry/SchoolRegistry.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/registry/SchoolRegistry.java
@@ -18,6 +18,7 @@ import net.neoforged.neoforge.registries.NewRegistryEvent;
 import net.neoforged.neoforge.registries.RegistryBuilder;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.function.Supplier;
 
 public class SchoolRegistry {
@@ -155,5 +156,9 @@ public class SchoolRegistry {
             }
         }
         return null;
+    }
+
+    public static List<SchoolType> getSchoolsFromFocus(ItemStack focusStack) {
+        return REGISTRY.stream().filter((school) -> school.isFocus(focusStack)).toList();
     }
 }

--- a/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeMenu.java
+++ b/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeMenu.java
@@ -111,7 +111,7 @@ public class ScrollForgeMenu extends AbstractContainerMenu {
         ItemStack inkStack = this.inkSlot.getItem();
         ItemStack focusStack = this.focusSlot.getItem();
         ItemStack resultStack = ItemStack.EMPTY;
-        if (!scrollStack.isEmpty() && !inkStack.isEmpty() && !focusStack.isEmpty() && !spell.equals(SpellRegistry.none()) && spell.getSchoolType() == SchoolRegistry.getSchoolFromFocus(focusStack)) {
+        if (!scrollStack.isEmpty() && !inkStack.isEmpty() && !focusStack.isEmpty() && !spell.equals(SpellRegistry.none()) && SchoolRegistry.getSchoolsFromFocus(focusStack).contains(spell.getSchoolType())) {
             if (scrollStack.getItem().equals(Items.PAPER) && inkStack.getItem() instanceof InkItem inkItem) {
                 resultStack = new ItemStack(ItemRegistry.SCROLL.get());
                 resultStack.setCount(1);

--- a/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeScreen.java
+++ b/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeScreen.java
@@ -173,9 +173,10 @@ public class ScrollForgeScreen extends AbstractContainerScreen<ScrollForgeMenu> 
         ItemStack focusStack = menu.getFocusSlot().getItem();
         IronsSpellbooks.LOGGER.info("ScrollForgeMenu.generateSpellSlots.focus: {}", focusStack.getItem());
         if (!focusStack.isEmpty() && focusStack.is(ModTags.SCHOOL_FOCUS)) {
-            SchoolType school = SchoolRegistry.getSchoolFromFocus(focusStack);
+            var schools = SchoolRegistry.getSchoolsFromFocus(focusStack);
             //irons_spellbooks.LOGGER.info("ScrollForgeMenu.generateSpellSlots.school: {}", school.toString());
-            var spells = SpellRegistry.getSpellsForSchool(school).stream().filter(AbstractSpell::allowCrafting).toList();
+            ArrayList<AbstractSpell> spells = new ArrayList<>();
+            schools.forEach((schoolType) -> spells.addAll(SpellRegistry.getSpellsForSchool(schoolType)));
             for (int i = 0; i < spells.size(); i++) {
                 //int id = spells[i].getValue();
                 int tempIndex = i;

--- a/src/main/java/io/redspace/ironsspellbooks/jei/ScrollForgeRecipeMaker.java
+++ b/src/main/java/io/redspace/ironsspellbooks/jei/ScrollForgeRecipeMaker.java
@@ -40,8 +40,11 @@ public final class ScrollForgeRecipeMaker {
                 .map(item -> {
                     var paperInput = new ItemStack(Items.PAPER);
                     var focusInput = new ItemStack(item);
-                    var school = SchoolRegistry.getSchoolFromFocus(focusInput);
-                    var spells = SpellRegistry.getSpellsForSchool(school);
+                    var schools = SchoolRegistry.getSchoolsFromFocus(focusInput);
+                    //irons_spellbooks.LOGGER.info("ScrollForgeMenu.generateSpellSlots.school: {}", school.toString());
+                    ArrayList<AbstractSpell> spells = new ArrayList<>();
+                    schools.forEach((schoolType) -> spells.addAll(SpellRegistry.getSpellsForSchool(schoolType)));
+
                     var scrollOutputs = new ArrayList<ItemStack>();
                     var inkOutputs = new ArrayList<ItemStack>();
 


### PR DESCRIPTION
I've added a new method, `SchoolRegistry.getSchoolsFromFocus()`, to get the list of schools of an item and changed the Scroll Forge (and its JEI preview) to account for the possibility of multiple schools from one focus item, meaning if an item is tagged as the focus for multiple schools, the spells from all of those schools will be displayed in the Forge/JEI. Doesn't actually change anything directly but it opens the door for addons and whatnot
![image](https://github.com/user-attachments/assets/b18ed928-fb16-4f8f-a77f-9beb8ffd1087)
![image](https://github.com/user-attachments/assets/60e73329-d4d7-44c1-b441-b5fb485c7da7)
(To demonstrate, I temporarily tagged the Blaze Rod as the focus for every school)

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
