### PR TITLE
Ability to customize uncraftable spell messages in the scroll forge on a per-spell basis

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
@@ -61,7 +61,6 @@ public abstract class AbstractSpell {
     private String spellID = null;
     private String deathMessageId = null;
     private String spellName = null;
-    private String lockedMessage = null;
     protected int baseManaCost;
     protected int manaCostPerLevel;
     protected int baseSpellPower;

--- a/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
@@ -61,6 +61,7 @@ public abstract class AbstractSpell {
     private String spellID = null;
     private String deathMessageId = null;
     private String spellName = null;
+    private String lockedMessage = null;
     protected int baseManaCost;
     protected int manaCostPerLevel;
     protected int baseSpellPower;
@@ -117,6 +118,8 @@ public abstract class AbstractSpell {
     public String getComponentId() {
         return String.format("spell.%s.%s", getSpellResource().getNamespace(), getSpellName());
     }
+
+    public String getLockedMessage(){return Component.translatable("ui.irons_spellbooks.unlearned_error").getString();}
 
     public abstract ResourceLocation getSpellResource();
 

--- a/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/spells/AbstractSpell.java
@@ -118,7 +118,7 @@ public abstract class AbstractSpell {
         return String.format("spell.%s.%s", getSpellResource().getNamespace(), getSpellName());
     }
 
-    public String getLockedMessage(){return Component.translatable("ui.irons_spellbooks.unlearned_error").getString();}
+    public Component getLockedMessage(){return Component.translatable("ui.irons_spellbooks.unlearned_error");}
 
     public abstract ResourceLocation getSpellResource();
 

--- a/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeScreen.java
+++ b/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeScreen.java
@@ -294,7 +294,7 @@ public class ScrollForgeScreen extends AbstractContainerScreen<ScrollForgeMenu> 
             if (this.activityState == ActivityState.INK_ERROR) {
                 return List.of(FormattedCharSequence.forward(Component.translatable("ui.irons_spellbooks.ink_rarity_error").getString(), Style.EMPTY));
             } else if (this.activityState == ActivityState.UNLEARNED_ERROR) {
-                return List.of(FormattedCharSequence.forward(Component.translatable("ui.irons_spellbooks.unlearned_error").getString(), Style.EMPTY));
+                return List.of(FormattedCharSequence.forward(this.spell.getLockedMessage(), Style.EMPTY));
             } else {
                 return TooltipsUtils.createSpellDescriptionTooltip(this.spell, font);
             }

--- a/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeScreen.java
+++ b/src/main/java/io/redspace/ironsspellbooks/gui/scroll_forge/ScrollForgeScreen.java
@@ -294,7 +294,7 @@ public class ScrollForgeScreen extends AbstractContainerScreen<ScrollForgeMenu> 
             if (this.activityState == ActivityState.INK_ERROR) {
                 return List.of(FormattedCharSequence.forward(Component.translatable("ui.irons_spellbooks.ink_rarity_error").getString(), Style.EMPTY));
             } else if (this.activityState == ActivityState.UNLEARNED_ERROR) {
-                return List.of(FormattedCharSequence.forward(this.spell.getLockedMessage(), Style.EMPTY));
+                return List.of(FormattedCharSequence.forward(this.spell.getLockedMessage().getString(), this.spell.getLockedMessage().getStyle()));
             } else {
                 return TooltipsUtils.createSpellDescriptionTooltip(this.spell, font);
             }


### PR DESCRIPTION
This is based on a suggestion I made a bit ago that allows the locked spell message shown by spells that have their crafting disabled to display a custom message that is defined through the getLockedMessage method in the AbstractSpell class. It doesn't modify anything player-side for eldritch spells as the default value for the method to return is the Component.translatable that it was before.

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
