### PR TITLE
Fixed mobs attributes on spawn, added fiery mobs tag in place of Blaze mob

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/player/ServerPlayerEvents.java
+++ b/src/main/java/io/redspace/ironsspellbooks/player/ServerPlayerEvents.java
@@ -82,6 +82,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.AnvilUpdateEvent;
 import net.neoforged.neoforge.event.ItemAttributeModifierEvent;
+import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.EntityMountEvent;
 import net.neoforged.neoforge.event.entity.EntityTravelToDimensionEvent;
 import net.neoforged.neoforge.event.entity.ProjectileImpactEvent;
@@ -569,9 +570,14 @@ public class ServerPlayerEvents {
         }
     }
 
-    @SubscribeEvent
-    public static void handleResistanceAttributesOnSpawn(FinalizeSpawnEvent event) {
-        var mob = event.getEntity();
+    // Optional: High event priority - in case other mods and addons want to modify these attributes, they will have priority by default
+    @SubscribeEvent//(priority = net.neoforged.bus.api.EventPriority.HIGH)
+    // EntityJoinLevelEvent makes sure the entity always has the attribute applied, even in already spawned, old entities
+    public static void handleResistanceAttributesOnSpawn(EntityJoinLevelEvent event) {
+        var entity = event.getEntity();
+        // We have to make sure it is a living entity for this event
+        if (!(entity instanceof LivingEntity mob)) return;
+
         //Attributes should never be null because all living entities have these attributes
         if (mob.getType().is(EntityTypeTags.UNDEAD)) {
             //Undead take extra holy damage, and less blood (necromantic) damage
@@ -585,8 +591,9 @@ public class ServerPlayerEvents {
             //Fire immune (blazes, pyromancer, etc) take 50% fire damage
             setIfNonNull(mob, AttributeRegistry.FIRE_MAGIC_RESIST, 1.5);
         }
-        //TODO: replace this with "fire_elemental" entity tag for all fiery mobs (blaze, magma cubes, modded mobs)
-        if (mob.getType() == EntityType.BLAZE) {
+        // Added FIERY_MOBS tag (includes Tyros and Pyromancer since the "TO DO" comment also said modded mobs)
+        // if (mob.getType() == EntityType.BLAZE) {
+        if (mob.getType().is(ModTags.FIERY_MOBS)) {
             setIfNonNull(mob, AttributeRegistry.ICE_MAGIC_RESIST, 0.5);
         }
     }

--- a/src/main/java/io/redspace/ironsspellbooks/player/ServerPlayerEvents.java
+++ b/src/main/java/io/redspace/ironsspellbooks/player/ServerPlayerEvents.java
@@ -570,9 +570,7 @@ public class ServerPlayerEvents {
         }
     }
 
-    // Optional: High event priority - in case other mods and addons want to modify these attributes, they will have priority by default
-    @SubscribeEvent//(priority = net.neoforged.bus.api.EventPriority.HIGH)
-    // EntityJoinLevelEvent makes sure the entity always has the attribute applied, even in already spawned, old entities
+    @SubscribeEvent
     public static void handleResistanceAttributesOnSpawn(EntityJoinLevelEvent event) {
         var entity = event.getEntity();
         // We have to make sure it is a living entity for this event
@@ -581,29 +579,39 @@ public class ServerPlayerEvents {
         //Attributes should never be null because all living entities have these attributes
         if (mob.getType().is(EntityTypeTags.UNDEAD)) {
             //Undead take extra holy damage, and less blood (necromantic) damage
-            setIfNonNull(mob, AttributeRegistry.HOLY_MAGIC_RESIST, 0.5);
-            setIfNonNull(mob, AttributeRegistry.BLOOD_MAGIC_RESIST, 1.5);
+            addUniqueModifier(mob, AttributeRegistry.HOLY_MAGIC_RESIST, -0.5);
+            addUniqueModifier(mob, AttributeRegistry.BLOOD_MAGIC_RESIST, 0.5);
         } else if (mob.getType().is(EntityTypeTags.SENSITIVE_TO_IMPALING)) {
             //Water mobs take extra lightning damage
-            setIfNonNull(mob, AttributeRegistry.LIGHTNING_MAGIC_RESIST, 0.5);
+            addUniqueModifier(mob, AttributeRegistry.LIGHTNING_MAGIC_RESIST, -0.5);
         }
         if (mob.fireImmune()) {
             //Fire immune (blazes, pyromancer, etc) take 50% fire damage
-            setIfNonNull(mob, AttributeRegistry.FIRE_MAGIC_RESIST, 1.5);
+            addUniqueModifier(mob, AttributeRegistry.FIRE_MAGIC_RESIST, 0.5);
         }
-        // Added FIERY_MOBS tag (includes Tyros and Pyromancer since the "TO DO" comment also said modded mobs)
-        // if (mob.getType() == EntityType.BLAZE) {
         if (mob.getType().is(ModTags.FIERY_MOBS)) {
-            setIfNonNull(mob, AttributeRegistry.ICE_MAGIC_RESIST, 0.5);
+            addUniqueModifier(mob, AttributeRegistry.ICE_MAGIC_RESIST, -0.5);
         }
     }
 
-    private static void setIfNonNull(LivingEntity mob, Holder<Attribute> attribute, double value) {
+    private static void addUniqueModifier(LivingEntity entity, Holder<Attribute> attribute, double value) {
+        var instance = entity.getAttributes().getInstance(attribute);
+        if (instance == null) return;
+
+        ResourceLocation id = ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "resistance");
+
+        //Makes sure the attribute isn't applied multiple times
+        if (instance.getModifiers().stream().noneMatch(mod -> mod.id().equals(id))) {
+            instance.addPermanentModifier(new AttributeModifier(id, value, AttributeModifier.Operation.ADD_VALUE));
+        }
+    }
+
+    /*private static void setIfNonNull(LivingEntity mob, Holder<Attribute> attribute, double value) {
         var instance = mob.getAttributes().getInstance(attribute);
         if (instance != null) {
             instance.setBaseValue(value);
         }
-    }
+    }*/
 
     @SubscribeEvent
     public static void onLivingTick(EntityTickEvent.Pre event) {

--- a/src/main/java/io/redspace/ironsspellbooks/util/ModTags.java
+++ b/src/main/java/io/redspace/ironsspellbooks/util/ModTags.java
@@ -43,6 +43,8 @@ public class ModTags {
     public static final TagKey<EntityType<?>> CANT_USE_PORTAL = TagKey.create(Registries.ENTITY_TYPE, new ResourceLocation(IronsSpellbooks.MODID, "cant_use_portal"));
     public static final TagKey<EntityType<?>> INFERNAL_ALLIES = TagKey.create(Registries.ENTITY_TYPE, new ResourceLocation(IronsSpellbooks.MODID, "infernal_allies"));
     public static final TagKey<EntityType<?>> GUIDING_BOLT_IMMUNE = TagKey.create(Registries.ENTITY_TYPE, new ResourceLocation(IronsSpellbooks.MODID, "guiding_bolt_immune"));
+    // Added FIERY_MOBS tag (includes Tyros and Pyromancer since those are also fire-related)
+    public static final TagKey<EntityType<?>> FIERY_MOBS = TagKey.create(Registries.ENTITY_TYPE, new ResourceLocation(IronsSpellbooks.MODID, "fiery_mobs"));
 
     public static final TagKey<Biome> ICE_SPIDER_PATROLS = TagKey.create(Registries.BIOME, new ResourceLocation(IronsSpellbooks.MODID, "ice_spider_patrols"));
 

--- a/src/main/resources/data/irons_spellbooks/tags/entity_type/fiery_mobs.json
+++ b/src/main/resources/data/irons_spellbooks/tags/entity_type/fiery_mobs.json
@@ -2,8 +2,6 @@
   "replace": false,
   "values": [
     "minecraft:blaze",
-    "minecraft:magma_cube",
-    "irons_spellbooks:pyromancer",
-    "irons_spellbooks:fire_boss"
+    "minecraft:magma_cube"
   ]
 }

--- a/src/main/resources/data/irons_spellbooks/tags/entity_type/fiery_mobs.json
+++ b/src/main/resources/data/irons_spellbooks/tags/entity_type/fiery_mobs.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:blaze",
+    "minecraft:magma_cube",
+    "irons_spellbooks:pyromancer",
+    "irons_spellbooks:fire_boss"
+  ]
+}


### PR DESCRIPTION
Fixed attributes not being properly applied to entities on spawn (Dead king and Tyros) by changing FinalizeSpawnEvent to EntityJoinLevelEvent.

Also, added FieryMobs tag as was under a TODO comment.

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
