### PR TITLE
Small change to move the "don't snap creative and spectator players into pocket dimension boxes" into its own method

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
@@ -45,6 +45,10 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         IronsDataStorage.INSTANCE.setDirty();
     }
 
+    public boolean shouldSnapPlayer(ServerPlayer player){
+        return !player.isCreative() && !player.isSpectator();
+    }
+
     private int nextId;
     //todo: should we store block position as well? would give freedom to change id hasher in the future
     private final Object2IntMap<UUID> ids = new Object2IntOpenHashMap<>();
@@ -146,7 +150,7 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         }
         if (serverLevel.getGameTime() % 100 == 0) {
             serverLevel.players().forEach(player -> {
-                if (!player.isCreative() && !player.isSpectator()) {
+                if (shouldSnapPlayer(player)) {
                     int pocketX = (int) (player.getX() / PocketDimensionManager.POCKET_SPACING) * PocketDimensionManager.POCKET_SPACING;
                     int pocketZ = (int) (player.getZ() / PocketDimensionManager.POCKET_SPACING) * PocketDimensionManager.POCKET_SPACING;
                     if (player.getX() < pocketX || player.getX() > pocketX + 16


### PR DESCRIPTION
This change lets mixins easily disable or modify the rules of the snapping inside the pocket dimension

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
