### PR TITLE
Backport: fix inverted pvp friendlyfire check

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/damage/DamageSources.java
+++ b/src/main/java/io/redspace/ironsspellbooks/damage/DamageSources.java
@@ -130,7 +130,7 @@ public class DamageSources {
         }
         if (attacker instanceof Player playerAttacker && target instanceof Player playertarget
                 && !playerAttacker.canHarmPlayer(playertarget)) {
-            return false;
+            return true;
         }
         var team = attacker.getTeam();
         if (team != null) {


### PR DESCRIPTION
Backports the friendly fire check fix addressing issue #829 from Commit 0402d77 in the 1.21.1 branch

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
