### PR TITLE
Backport of a attribute typo patch

### DIFF
--- a/src/main/resources/assets/irons_spellbooks/lang/en_us.json
+++ b/src/main/resources/assets/irons_spellbooks/lang/en_us.json
@@ -1017,7 +1017,7 @@
   "affix.irons_spellbooks:armor/attribute/cooldown.suffix": "of the Fast-Wit",
   "affix.irons_spellbooks:armor/attribute/spell_power": "Spellcasting",
   "affix.irons_spellbooks:armor/attribute/spell_power.suffix": "of the Spellcaster",
-  "affix.irons_spellbooks:armor/attribute/spell_resist": "Spellshieled",
+  "affix.irons_spellbooks:armor/attribute/spell_resist": "Spellshielded",
   "affix.irons_spellbooks:armor/attribute/spell_resist.suffix": "of the Magehunter",
   "affix.irons_spellbooks:spellbook/attribute/mana": "Intelligent",
   "affix.irons_spellbooks:spellbook/attribute/mana.suffix": "of the Intelligent",


### PR DESCRIPTION
This is a backport from commit 938cb2c that is in the 1.21 version, but not this one

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
