### PR TITLE
Add Korean translation (ko_kr.json)

### DIFF
--- a/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
+++ b/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
@@ -1223,5 +1223,21 @@
   "advancements.irons_spellbooks.spell_book_blood.title": "자신의 일부",
   "advancements.irons_spellbooks.spell_book_blood.description": "흡혈귀의 주문서를 제작하세요",
   "advancements.irons_spellbooks.pyrium_staff.title": "고대의 부름",
-  "advancements.irons_spellbooks.pyrium_staff.description": "파이리움 지팡이를 제작하세요"
+  "advancements.irons_spellbooks.pyrium_staff.description": "파이리움 지팡이를 제작하세요",
+  "item.irons_spellbooks.infernal_sorcerer_chestplate": "지옥불 마법사 흉갑",
+"item.irons_spellbooks.infernal_sorcerer_chestplate.desc": "화염 주문 피해를 입히면 대상에게 연소(Immolation) 중첩을 부여합니다.",
+"item.irons_spellbooks.infernal_sorcerer_chestplate.immolate.desc": "연소 중첩이 3회 되면 폭발(%s 피해)을 일으키고 연소를 주변으로 확산시킵니다.",
+"item.irons_spellbooks.twilight_gale": "황혼의 돌풍",
+"item.irons_spellbooks.chronicle": "연대기",
+"item.irons_spellbooks.chronicle.chapter": "제 %s장:\n",
+"item.irons_spellbooks.chronicle.chapter_1": "충성스러운 영혼들",
+"item.irons_spellbooks.chronicle.chapter_2": "신실한 영혼들",
+"item.irons_spellbooks.chronicle.chapter_3": "길 잃은 영혼들",
+"tooltip.irons_spellbooks.passive_ability_no_cooldown": "지속 능력:",
+"spell.irons_spellbooks.volt_strike": "볼트 스트라이크",
+"spell.irons_spellbooks.volt_strike.guide": "전방으로 도약하며 회전하는 전격 공격을 가합니다. 처음 적중한 대상이나 표면에 피해를 주고, 충격 지점 주변의 좁은 지역에 잔류 폭발 피해를 입힙니다.",
+"death.attack.irons_spellbooks.volt_strike": "%2$s의 볼트 스트라이크에 의해 %1$s이(가) 쓰러졌습니다.",
+"death.attack.irons_spellbooks.volt_strike.item": "%2$s의 %3$s(으)로 시전한 볼트 스트라이크에 의해 %1$s이(가) 쓰러졌습니다.",
+"effect.irons_spellbooks.immolate": "연소",
+"effect.irons_spellbooks.immolate.description": "연소 중첩이 3회에 도달하면 대상 생명체가 폭발하여 피해를 입히고 주변 생명체에게 연소를 확산시킵니다."
 }


### PR DESCRIPTION
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [ ] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
