### PR TITLE
[API] (WIP) Initial SpellPreCastClientEvent design

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/api/events/client/SpellPreCastClientEvent.java
+++ b/src/main/java/io/redspace/ironsspellbooks/api/events/client/SpellPreCastClientEvent.java
@@ -1,0 +1,42 @@
+package io.redspace.ironsspellbooks.api.events.client;
+
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Similarly to {@link io.redspace.ironsspellbooks.api.events.SpellPreCastEvent},
+ * this event is fired whenever a {@link Player} is about to cast a spell,
+ * but before any packet is sent to the server.
+ * This event is called only on the physical client.
+ *
+ * <p>This event is {@link ICancellableEvent cancellable}.
+ * Cancelling this event prevents the spell cast packet from being sent.</p>
+ * <br>
+ * This event does not have a result.<br>
+ *
+ * <p>This event is fired on the {@link net.neoforged.neoforge.common.NeoForge#EVENT_BUS}.</p>
+ **/
+public class SpellPreCastClientEvent extends PlayerEvent implements ICancellableEvent {
+    private final @NotNull SpellPreCastClientEvent.CastTriggerType triggerType;
+
+    public SpellPreCastClientEvent(@NotNull LocalPlayer player, @NotNull SpellPreCastClientEvent.CastTriggerType triggerType) {
+        super(player);
+        this.triggerType = triggerType;
+    }
+
+    public enum CastTriggerType {
+        CAST_SELECTED_SPELL,
+        QUICK_CAST;
+
+        public boolean isSpellBookCast() {
+            return this == CAST_SELECTED_SPELL || this == QUICK_CAST;
+        }
+    }
+
+    public @NotNull SpellPreCastClientEvent.CastTriggerType getTriggerType() {
+        return this.triggerType;
+    }
+}

--- a/src/main/java/io/redspace/ironsspellbooks/player/ClientInputEvents.java
+++ b/src/main/java/io/redspace/ironsspellbooks/player/ClientInputEvents.java
@@ -2,6 +2,7 @@ package io.redspace.ironsspellbooks.player;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import io.redspace.ironsspellbooks.IronsSpellbooks;
+import io.redspace.ironsspellbooks.api.events.client.SpellPreCastClientEvent;
 import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.config.ClientConfigs;
 import io.redspace.ironsspellbooks.gui.overlays.ManaBarOverlay;
@@ -10,7 +11,6 @@ import io.redspace.ironsspellbooks.gui.overlays.SpellWheelOverlay;
 import io.redspace.ironsspellbooks.network.casting.CastPacket;
 import io.redspace.ironsspellbooks.network.casting.QuickCastPacket;
 import io.redspace.ironsspellbooks.util.MinecraftInstanceHelper;
-import io.redspace.ironsspellbooks.worldgen.AquiferHelper;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.Mth;
@@ -20,10 +20,13 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.client.event.InputEvent;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.PacketDistributor;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.redspace.ironsspellbooks.player.KeyMappings.SPELLBOOK_CAST_ACTIVE_KEYMAP;
 
@@ -106,12 +109,16 @@ public final class ClientInputEvents {
         }
         for (int i = 0; i < QUICK_CAST_STATES.size(); i++) {
             if (QUICK_CAST_STATES.get(i).wasPressed()) {
-                PacketDistributor.sendToServer(new QuickCastPacket(i));
+                if (firePreCastEvent(SpellPreCastClientEvent.CastTriggerType.QUICK_CAST)) {
+                    PacketDistributor.sendToServer(new QuickCastPacket(i));
+                }
                 break;
             }
         }
         if (SPELLBOOK_CAST_STATE.wasPressed() && minecraft.screen == null) {
-            PacketDistributor.sendToServer(new CastPacket());
+            if (firePreCastEvent(SpellPreCastClientEvent.CastTriggerType.CAST_SELECTED_SPELL)) {
+                PacketDistributor.sendToServer(new CastPacket());
+            }
         }
         if (SPELL_WHEEL_STATE.wasPressed()) {
             if (minecraft.screen == null) {
@@ -178,5 +185,18 @@ public final class ClientInputEvents {
         });
 
         return keyStates;
+    }
+
+    /**
+     * Fires a {@link SpellPreCastClientEvent} and returns whether the event was not canceled.
+     *
+     * @return {@code true} if the event was not canceled, {@code false} otherwise
+     */
+    private static boolean firePreCastEvent(final @NotNull SpellPreCastClientEvent.CastTriggerType triggerType) {
+        final SpellPreCastClientEvent event = new SpellPreCastClientEvent(
+                Objects.requireNonNull(Minecraft.getInstance().player, "must be called only on the client-side"),
+                triggerType
+        );
+        return !NeoForge.EVENT_BUS.post(event).isCanceled();
     }
 }


### PR DESCRIPTION
Fixes #955

### WIP

The new event is not fired when using a scroll item (right-click), since I'm not sure how to implement this while making `SpellPreCastClientEvent` cancellable and without any mixins.

`Scroll#use()` is called on both the server and client, on the client first, so I assumed there is a way to prevent the packet from being sent, but there isn't.

We could make `SpellPreCastClientEvent` non-cancellable; however, I'm looking for better alternatives.

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
