### PR TITLE
Fix ISS-3.14.7 from crashing with Create Pondering

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/mixin/LevelMixin.java
+++ b/src/main/java/io/redspace/ironsspellbooks/mixin/LevelMixin.java
@@ -23,7 +23,7 @@ public class LevelMixin {
 
     @Inject(method = "<init>", at = @At(value = "RETURN"))
     private void noopWorldBorder(WritableLevelData levelData, ResourceKey dimension, RegistryAccess registryAccess, Holder dimensionTypeRegistration, Supplier profiler, boolean isClientSide, boolean isDebug, long biomeZoomSeed, int maxChainedNeighborUpdates, CallbackInfo ci) {
-        if (dimension.equals(PocketDimensionManager.POCKET_DIMENSION)) {
+        if (dimension != null && dimension.equals(PocketDimensionManager.POCKET_DIMENSION)) {
             worldBorder = new NoopWorldBorder();
         }
     }


### PR DESCRIPTION
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.

This fixes an issue with Create pondering and the Level mixin

Error before fixing it:
```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "dimension" is null
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.handler$dnk000$irons_spellbooks$noopWorldBorder(Level.java:9322)
```
	
Fixes #980