### PR TITLE
[1.21.1] Automated mod publishing to CurseForge and Modrinth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'net.neoforged.gradle.userdev' version '7.0.182'
+    id("me.modmuss50.mod-publish-plugin") version "1.1.0"
 }
 
 version = mod_version
@@ -10,6 +11,7 @@ group = mod_group_id
 
 base {
     archivesName = mod_id
+    version = getFullModVersion()
 }
 
 // Mojang ships Java 21 to end users starting in 1.20.5, so mods should target Java 21.
@@ -238,5 +240,57 @@ idea {
     module {
         downloadSources = true
         downloadJavadoc = true
+    }
+}
+
+def getFullModVersion() {
+    return "${mod_version}-mc${minecraft_version}-neoforge"
+}
+
+publishMods {
+    def releaseNotesFile = project.file("LATEST_CHANGES.MD")
+    def releaseNotesContent = releaseNotesFile.text
+
+    changelog = """
+|**Tested against:**
+|- **NeoForge:** ${neo_version}
+|- **Minecraft:** ${minecraft_version}
+|- **playerAnimator:** ${player_animator_version}
+|- **Curios API:** ${curios_version}
+|- **GeckoLib:** ${geckolib_version}
+|
+|${releaseNotesContent}
+""".stripMargin().trim()
+
+    modLoaders.add("neoforge")
+    type = STABLE
+    displayName = getFullModVersion()
+    file = tasks.jar.archiveFile
+    additionalFiles.from(sourcesJar, apiJar)
+
+    curseforge {
+        accessToken = System.getenv("CURSEFORGE_TOKEN")
+        projectId = "855414"
+        minecraftVersions.add(minecraft_version)
+        projectSlug = "irons-spells-n-spellbooks"
+
+        requires("playeranimator")
+        requires("curios")
+        requires("geckolib")
+        requires("caelus")
+    }
+
+    modrinth {
+        accessToken = System.getenv("MODRINTH_TOKEN")
+        projectId = "s4OWxYQQ"
+        minecraftVersions.add(minecraft_version)
+
+        requires("playeranimator")
+        requires("curios")
+        requires("geckolib")
+        requires("caelus")
+
+        // Syncs the GitHub README with the Modrinth project description
+        // projectDescription = file("README.md").text
     }
 }


### PR DESCRIPTION
Set up automated mod publishing to CurseForge and Modrinth platforms.

* Can be triggered by running `./gradlew publishMods` or `publishModrinth`, or `publishCurseForge`.
* The release notes for the current version are in `LATEST_CHANGES.md` (current file).
* Tokens can be obtained from CurseForge and Modrinth platforms. For more details, refer to [Mod Publish Gradle Plugin](https://modmuss50.github.io/mod-publish-plugin/).
* The tokens can be specified either in the environment variables of the maintainers' system or in the IDEA run configuration task.

This was done for 5 reasons:

* Caelus API is a required mod dependency, but not specified in CurseForge or Modrinth.
* Mod dependencies are not specified at all on Modrinth.
* Newer versions are not uploaded to Modrinth, so I assume the current publishing workflow is manual. Modrinth is more open, community-driven, and also open-source, so I personally consider supporting it too.
* Some addon devs chose not to use the provided Maven repository by ISS, so the API and "sources" JAR files are not provided. This fixes that, since Modrinth modrinth will automatically make use of the `-sources.jar`, and Curse Forge supports including any optional file manually.
* This automatically includes the version that was tested against, so in case of a crash due to breaking changes of dependencies, users will have a way of knowing which version supports which dependency versions.

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
