### PR TITLE
Fix null pointer exception in particle spawning logic to prevent crash on the client

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/MagicManager.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/MagicManager.java
@@ -13,6 +13,7 @@ import io.redspace.ironsspellbooks.item.Scroll;
 import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import io.redspace.ironsspellbooks.network.casting.SyncCooldownPacket;
 import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
@@ -20,6 +21,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.Objects;
 
 import static io.redspace.ironsspellbooks.api.registry.AttributeRegistry.*;
 
@@ -124,6 +127,18 @@ public class MagicManager implements IMagicManager {
     }
 
     public static void spawnParticles(Level level, ParticleOptions particle, double x, double y, double z, int count, double deltaX, double deltaY, double deltaZ, double speed, boolean force) {
-        level.getServer().getPlayerList().getPlayers().forEach(player -> ((ServerLevel) level).sendParticles(player, particle, force, x, y, z, count, deltaX, deltaY, deltaZ, speed));
+        if (level.isClientSide) {
+            return;
+        }
+
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
+        MinecraftServer server = serverLevel.getServer();
+
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            serverLevel.sendParticles(player, particle, force, x, y, z, count, deltaX, deltaY, deltaZ, speed);
+        }
     }
 }

--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/MagicManager.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/MagicManager.java
@@ -13,7 +13,6 @@ import io.redspace.ironsspellbooks.item.Scroll;
 import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import io.redspace.ironsspellbooks.network.casting.SyncCooldownPacket;
 import net.minecraft.core.particles.ParticleOptions;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
@@ -21,8 +20,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.PacketDistributor;
-
-import java.util.Objects;
 
 import static io.redspace.ironsspellbooks.api.registry.AttributeRegistry.*;
 
@@ -135,9 +132,7 @@ public class MagicManager implements IMagicManager {
             return;
         }
 
-        MinecraftServer server = serverLevel.getServer();
-
-        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+        for (ServerPlayer player : serverLevel.getServer().getPlayerList().getPlayers()) {
             serverLevel.sendParticles(player, particle, force, x, y, z, count, deltaX, deltaY, deltaZ, speed);
         }
     }


### PR DESCRIPTION
### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.

I am submitting this PR because another mod ([T.O Magic 'n Extras - Iron's Spells Addon](https://www.curseforge.com/minecraft/mc-mods/to-tweaks-irons-spells/files/6342780)) uses the spawnParticles method in the client and it crashes the game because it is not handled properly.