### PR TITLE
Added an empty tag to prevent projectiles from being parried by Shadow Slash

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/spells/ender/ShadowSlashSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/ender/ShadowSlashSpell.java
@@ -13,6 +13,7 @@ import io.redspace.ironsspellbooks.particle.EnderSlashParticleOptions;
 import io.redspace.ironsspellbooks.particle.TraceParticleOptions;
 import io.redspace.ironsspellbooks.registries.MobEffectRegistry;
 import io.redspace.ironsspellbooks.registries.SoundRegistry;
+import io.redspace.ironsspellbooks.util.ModTags;
 import io.redspace.ironsspellbooks.util.ParticleHelper;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -107,7 +108,7 @@ public class ShadowSlashSpell extends AbstractSpell {
             var damageSource = this.getDamageSource(entity);
             boolean projectileEffects = false;
             for (Entity targetEntity : damageEntities) {
-                if (targetEntity instanceof Projectile projectile && !projectile.noPhysics) {
+                if (targetEntity instanceof Projectile projectile && !projectile.noPhysics && !projectile.getType().is(ModTags.CANT_PARRY)) {
                     projectileEffects = true;
                     projectile.setOwner(entity);
                     projectile.shoot(forward.x, forward.y, forward.z, (float) projectile.getDeltaMovement().length(), 0f);

--- a/src/main/java/io/redspace/ironsspellbooks/util/ModTags.java
+++ b/src/main/java/io/redspace/ironsspellbooks/util/ModTags.java
@@ -48,6 +48,7 @@ public class ModTags {
     public static final TagKey<EntityType<?>> INFERNAL_ALLIES = TagKey.create(Registries.ENTITY_TYPE, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "infernal_allies"));
     public static final TagKey<EntityType<?>> GUIDING_BOLT_IMMUNE = TagKey.create(Registries.ENTITY_TYPE, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "guiding_bolt_immune"));
     public static final TagKey<EntityType<?>> CANT_PRODUCE_BLOOD = TagKey.create(Registries.ENTITY_TYPE, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "cant_produce_blood"));
+    public static final TagKey<EntityType<?>> CANT_PARRY = TagKey.create(Registries.ENTITY_TYPE, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "cant_parry"));
 
     public static final TagKey<Biome> ICE_SPIDER_PATROLS = TagKey.create(Registries.BIOME, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "ice_spider_patrols"));
 

--- a/src/main/resources/data/irons_spellbooks/tags/entity_type/cant_parry.json
+++ b/src/main/resources/data/irons_spellbooks/tags/entity_type/cant_parry.json
@@ -1,0 +1,5 @@
+{
+  "replace": false,
+  "values": [
+  ]
+}


### PR DESCRIPTION
This is largely for better compatibility with other mods/addons as some attacks can cause slight problems (Scylla's anchor from Cataclysm) and other addons might implement their own parry mechanics or have spells that shouldn't be parried.

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
