### PR TITLE
Improve Spider Aspect flexibility with MobEffect Tags

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/effect/SpiderAspectEffect.java
+++ b/src/main/java/io/redspace/ironsspellbooks/effect/SpiderAspectEffect.java
@@ -1,8 +1,13 @@
 package io.redspace.ironsspellbooks.effect;
 
+import io.redspace.ironsspellbooks.IronsSpellbooks;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import io.redspace.ironsspellbooks.registries.MobEffectRegistry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
-import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -11,6 +16,8 @@ import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 @EventBusSubscriber
 public class SpiderAspectEffect extends MagicMobEffect {
     public static final float DAMAGE_PER_LEVEL = .05f;
+    public static final TagKey<MobEffect> AFFECTED_BY_SPIDER_ASPECT =
+            TagKey.create(Registries.MOB_EFFECT, new ResourceLocation(IronsSpellbooks.MODID, "affected_by_spider_aspect"));
 
     public SpiderAspectEffect(MobEffectCategory pCategory, int pColor) {
         super(pCategory, pColor);
@@ -24,8 +31,12 @@ public class SpiderAspectEffect extends MagicMobEffect {
             /**
              * Spider aspect handling
              */
+            
             if (livingAttacker.hasEffect(MobEffectRegistry.SPIDER_ASPECT)) {
-                if (event.getEntity().hasEffect(MobEffects.POISON)) {
+                boolean targetHasTagEffect = event.getEntity().getActiveEffects().stream()
+                        .anyMatch(instance -> instance.getEffect().is(AFFECTED_BY_SPIDER_ASPECT));
+
+                if (targetHasTagEffect) {
                     int lvl = livingAttacker.getEffect(MobEffectRegistry.SPIDER_ASPECT).getAmplifier() + 1;
                     float before = event.getAmount();
                     float multiplier = 1 + SpiderAspectEffect.DAMAGE_PER_LEVEL * lvl;

--- a/src/main/java/io/redspace/ironsspellbooks/effect/SpiderAspectEffect.java
+++ b/src/main/java/io/redspace/ironsspellbooks/effect/SpiderAspectEffect.java
@@ -1,12 +1,7 @@
 package io.redspace.ironsspellbooks.effect;
 
-import io.redspace.ironsspellbooks.IronsSpellbooks;
-import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import io.redspace.ironsspellbooks.registries.MobEffectRegistry;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.util.ModTags;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -16,8 +11,6 @@ import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 @EventBusSubscriber
 public class SpiderAspectEffect extends MagicMobEffect {
     public static final float DAMAGE_PER_LEVEL = .05f;
-    public static final TagKey<MobEffect> AFFECTED_BY_SPIDER_ASPECT =
-            TagKey.create(Registries.MOB_EFFECT, new ResourceLocation(IronsSpellbooks.MODID, "affected_by_spider_aspect"));
 
     public SpiderAspectEffect(MobEffectCategory pCategory, int pColor) {
         super(pCategory, pColor);
@@ -34,7 +27,7 @@ public class SpiderAspectEffect extends MagicMobEffect {
             
             if (livingAttacker.hasEffect(MobEffectRegistry.SPIDER_ASPECT)) {
                 boolean targetHasTagEffect = event.getEntity().getActiveEffects().stream()
-                        .anyMatch(instance -> instance.getEffect().is(AFFECTED_BY_SPIDER_ASPECT));
+                        .anyMatch(instance -> instance.getEffect().is(ModTags.AFFECTED_BY_SPIDER_ASPECT));
 
                 if (targetHasTagEffect) {
                     int lvl = livingAttacker.getEffect(MobEffectRegistry.SPIDER_ASPECT).getAmplifier() + 1;

--- a/src/main/java/io/redspace/ironsspellbooks/util/ModTags.java
+++ b/src/main/java/io/redspace/ironsspellbooks/util/ModTags.java
@@ -39,6 +39,8 @@ public class ModTags {
     public static final TagKey<Block> PREVENT_POCKET_DIMENSION_PLACEMENT = BlockTags.create(ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "pocket_dimension_prevent_placement"));
 
     public static final TagKey<MobEffect> CLEANSE_IMMUNE = TagKey.create(Registries.MOB_EFFECT, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "cleanse_immune"));
+    public static final TagKey<MobEffect> AFFECTED_BY_SPIDER_ASPECT = TagKey.create(Registries.MOB_EFFECT, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "affected_by_spider_aspect"));
+
     public static final TagKey<Structure> WAYWARD_COMPASS_LOCATOR = TagKey.create(Registries.STRUCTURE, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "wayward_compass_locator"));
 
     public static final TagKey<EntityType<?>> ALWAYS_HEAL = TagKey.create(Registries.ENTITY_TYPE, ResourceLocation.fromNamespaceAndPath(IronsSpellbooks.MODID, "always_heal"));


### PR DESCRIPTION
Summary
This PR transitions the `SpiderAspectEffect` from a hardcoded `Poison` check to a data-driven Tag system.

Changes
- Created `AFFECTED_BY_SPIDER_ASPECT` using the `affected_by_spider_aspect` ResourceLocation.
- Updated `increaseDamage` logic to check if the target has any effect present in the new tag.

Why?
This allows for much better mod compatibility and customization. Users can now add effects like Wither, custom Venoms, or other debuffs to the "Spider Aspect" bonus damage via simple JSON data packs without needing to modify the source code.

Missing
- affected_by_spider_aspect tag file

### Contributor Liscence Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
