### PR TITLE
Fix create fluid notation

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/command/CreateRecipeCompatGenerator.java
+++ b/src/main/java/io/redspace/ironsspellbooks/command/CreateRecipeCompatGenerator.java
@@ -107,7 +107,7 @@ public class CreateRecipeCompatGenerator {
                       "ingredients": [
                         %s,
                         {
-                          "type": "fluid_stack",
+                          "type": "neoforge:single",
                           "fluid": "%s",
                           "amount": %s
                         }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_blood_vial.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_blood_vial.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:blood",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_common_ink.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_common_ink.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:common_ink",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_epic_ink.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_epic_ink.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:epic_ink",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_evasion_elixir.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_evasion_elixir.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:evasion_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_evasion_elixir.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_evasion_elixir.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:greater_evasion_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_healing_potion.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_healing_potion.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:greater_healing_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_invisibility_elixir.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_invisibility_elixir.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:greater_invisibility_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_oakskin_elixir.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_greater_oakskin_elixir.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:greater_oakskin_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_ice_venom_vial.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_ice_venom_vial.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:ice_venom",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_invisibility_elixir.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_invisibility_elixir.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:invisibility_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_legendary_ink.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_legendary_ink.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:legendary_ink",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_oakskin_elixir.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_oakskin_elixir.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:oakskin_elixir",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_rare_ink.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_rare_ink.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:rare_ink",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_timeless_slurry.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_timeless_slurry.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:timeless_slurry",
       "amount": 250
     }

--- a/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_uncommon_ink.json
+++ b/src/main/resources/data/irons_spellbooks/recipe/create_compat/create_fill_uncommon_ink.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass_bottle"
     },
     {
-      "type": "fluid_stack",
+      "type": "neoforge:single",
       "fluid": "irons_spellbooks:uncommon_ink",
       "amount": 250
     }


### PR DESCRIPTION
A small fix to create compat, fixing recipe notation, to avoid errors.

the error in question:
```
Failed to parse recipe 'irons_spellbooks:create_compat/create_fill_oakskin_elixir[create:filling]'! Falling back to vanilla: Failed to read required component 'ingredients: either<create:sized_fluid_ingredient, ingredient>[]' - java.lang.IllegalStateException: Failed to parse either. First: Unknown registry key in ResourceKey[minecraft:root / neoforge:fluid_ingredient_type]: minecraft:fluid_stack; Unknown registry key in ResourceKey[minecraft:root / neoforge:fluid_ingredient_type]: minecraft:fluid_stack; Second: Failed to parse either. First: Not a json array: {"type":"fluid_stack","fluid":"irons_spellbooks:oakskin_elixir","amount":250}; Second: Unknown registry key in ResourceKey[minecraft:root / neoforge:ingredient_serializer]: minecraft:fluid_stack
```
The recipes don't break because of this error, but for the sake of cleanliness I feel like it would be preferred not to have them.

This format is consistent with what create uses [here](https://github.com/Creators-of-Create/Create/blob/mc1.21.1/dev/src/generated/resources/data/create/recipe/filling/blaze_cake.json).

### Contributor License Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.