### PR TITLE
Korean translation

### DIFF
--- a/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
+++ b/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
@@ -1223,5 +1223,21 @@
   "advancements.irons_spellbooks.spell_book_blood.title": "자신의 일부",
   "advancements.irons_spellbooks.spell_book_blood.description": "흡혈귀의 주문서를 제작하세요",
   "advancements.irons_spellbooks.pyrium_staff.title": "고대의 부름",
-  "advancements.irons_spellbooks.pyrium_staff.description": "파이리움 지팡이를 제작하세요"
+  "advancements.irons_spellbooks.pyrium_staff.description": "파이리움 지팡이를 제작하세요",
+  "item.irons_spellbooks.infernal_sorcerer_chestplate": "지옥불 마법사 흉갑",
+"item.irons_spellbooks.infernal_sorcerer_chestplate.desc": "화염 주문 피해를 입히면 대상에게 연소(Immolation) 중첩을 부여합니다.",
+"item.irons_spellbooks.infernal_sorcerer_chestplate.immolate.desc": "연소 중첩이 3회 되면 폭발(%s 피해)을 일으키고 연소를 주변으로 확산시킵니다.",
+"item.irons_spellbooks.twilight_gale": "황혼의 돌풍",
+"item.irons_spellbooks.chronicle": "연대기",
+"item.irons_spellbooks.chronicle.chapter": "제 %s장:\n",
+"item.irons_spellbooks.chronicle.chapter_1": "충성스러운 영혼들",
+"item.irons_spellbooks.chronicle.chapter_2": "신실한 영혼들",
+"item.irons_spellbooks.chronicle.chapter_3": "길 잃은 영혼들",
+"tooltip.irons_spellbooks.passive_ability_no_cooldown": "지속 능력:",
+"spell.irons_spellbooks.volt_strike": "볼트 스트라이크",
+"spell.irons_spellbooks.volt_strike.guide": "전방으로 도약하며 회전하는 전격 공격을 가합니다. 처음 적중한 대상이나 표면에 피해를 주고, 충격 지점 주변의 좁은 지역에 잔류 폭발 피해를 입힙니다.",
+"death.attack.irons_spellbooks.volt_strike": "%2$s의 볼트 스트라이크에 의해 %1$s이(가) 쓰러졌습니다.",
+"death.attack.irons_spellbooks.volt_strike.item": "%2$s의 %3$s(으)로 시전한 볼트 스트라이크에 의해 %1$s이(가) 쓰러졌습니다.",
+"effect.irons_spellbooks.immolate": "연소",
+"effect.irons_spellbooks.immolate.description": "연소 중첩이 3회에 도달하면 대상 생명체가 폭발하여 피해를 입히고 주변 생명체에게 연소를 확산시킵니다."
 }

--- a/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
+++ b/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
@@ -1251,5 +1251,18 @@
   "death.attack.irons_spellbooks.throw.item": "%1$s는 %2$s가 던진 %3$s에 의해 살해당했습니다",
   "effect.irons_spellbooks.fall_damage_immunity": "낙하 피해 면역",
   "effect.irons_spellbooks.fall_damage_immunity.description": "효과가 지속되는 동안 낙하 피해를 받지 않습니다.",
-  "entity.irons_spellbooks.thrown_item": "던져진 아이템"
+  "entity.irons_spellbooks.thrown_item": "던져진 아이템",
+  "item.irons_spellbooks.ice_spider_pheromones": "얼음 거미 페로몬",
+"item.irons_spellbooks.music_disc_whispers_of_ice": "음반",
+"item.irons_spellbooks.unchained_book": "해방된 마법서",
+"block.irons_spellbooks.tyros_statue": "티로스의 조각상",
+"effect.irons_spellbooks.ice_spider_lure": "얼음 거미 유인",
+"effect.irons_spellbooks.ice_spider_lure.description": "효과가 끝나면 얼음 거미가 생성되어 당신을 추적합니다.",     
+"commands.irons_spellbooks.generic.unknown_spell": "알 수 없는 주문 ID: %s",
+"commands.irons_spellbooks.generic.create_file": "성공적으로 %s 파일을 생성했습니다.",
+"commands.irons_spellbooks.config.cant_override": "설정 %s이(가) 이미 존재합니다. 계속하려면 파일을 삭제하거나 명령어에 'override'를 추가하세요.",
+"commands.irons_spellbooks.config_load_errors": "[Iron's Spells 'n Spellbooks]: 월드 주문 설정에 오류가 있습니다! 자세한 내용은 서버 로그를 확인하세요.",
+"fluid_type.irons_spellbooks.ice_spider_pheromone": "얼음 거미 페로몬 액체",
+"jukebox_song.irons_spellbooks.whispers_of_ice": "카네르 크레베스 - 얼음의 속삭임",
+"pattern.irons_spellbooks.rune_inscribed_ring.guide": "이 문양은 세계 곳곳에서 발견하거나 거래를 통해 얻을 수 있습니다."
 }

--- a/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
+++ b/src/main/resources/assets/irons_spellbooks/lang/ko_kr.json
@@ -1239,5 +1239,17 @@
 "death.attack.irons_spellbooks.volt_strike": "%2$s의 볼트 스트라이크에 의해 %1$s이(가) 쓰러졌습니다.",
 "death.attack.irons_spellbooks.volt_strike.item": "%2$s의 %3$s(으)로 시전한 볼트 스트라이크에 의해 %1$s이(가) 쓰러졌습니다.",
 "effect.irons_spellbooks.immolate": "연소",
-"effect.irons_spellbooks.immolate.description": "연소 중첩이 3회에 도달하면 대상 생명체가 폭발하여 피해를 입히고 주변 생명체에게 연소를 확산시킵니다."
+"effect.irons_spellbooks.immolate.description": "연소 중첩이 3회에 도달하면 대상 생명체가 폭발하여 피해를 입히고 주변 생명체에게 연소를 확산시킵니다.",
+"tooltip.irons_spellbooks.imbued_tooltip_plural": "각인된 주문:",
+  "spell.irons_spellbooks.shadow_slash": "그림자 베기",
+  "spell.irons_spellbooks.throw": "던지기",
+  "spell.irons_spellbooks.shadow_slash.guide": "비전 에너지로 호를 그리며 돌진해 전방의 생명체들을 공격합니다. 날아오는 투사체를 반사합니다. 착용 무기의 근접 피해량과 부여 효과에 비례하여 위력이 증가합니다.",
+  "spell.irons_spellbooks.throw.guide": "시전하면 손에 들고 있는 아이템을 던져, 기본 피해량에 아이템이 원래 입히는 피해량을 더한 피해를 입힙니다.",
+  "death.attack.irons_spellbooks.shadow_slash": "%1$s는 %2$s에게 베였습니다",
+  "death.attack.irons_spellbooks.throw": "%1$s는 %2$s에게 살해당했습니다",
+  "death.attack.irons_spellbooks.shadow_slash.item": "%1$s는 %2$s의 %3$s에 의해 베였습니다",
+  "death.attack.irons_spellbooks.throw.item": "%1$s는 %2$s가 던진 %3$s에 의해 살해당했습니다",
+  "effect.irons_spellbooks.fall_damage_immunity": "낙하 피해 면역",
+  "effect.irons_spellbooks.fall_damage_immunity.description": "효과가 지속되는 동안 낙하 피해를 받지 않습니다.",
+  "entity.irons_spellbooks.thrown_item": "던져진 아이템"
 }


### PR DESCRIPTION
### Contributor License Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [ ] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
