### PR TITLE
Fix Blood Step stale cast data crash

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/spells/blood/BloodStepSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/blood/BloodStepSpell.java
@@ -95,7 +95,7 @@ public class BloodStepSpell extends AbstractSpell {
     @Override
     public void onCast(Level level, int spellLevel, LivingEntity entity, CastSource castSource, MagicData playerMagicData) {
         Vec3 dest = null;
-        var teleportData = (TeleportSpell.TeleportData) playerMagicData.getAdditionalCastData();
+        var teleportData = playerMagicData.getAdditionalCastData() instanceof TeleportSpell.TeleportData data ? data : null;
         if (teleportData != null) {
             var potentialTarget = teleportData.getTeleportTargetPosition();
             if (potentialTarget != null) {
@@ -133,6 +133,8 @@ public class BloodStepSpell extends AbstractSpell {
         entity.setInvisible(true);
         entity.addEffect(new MobEffectInstance(MobEffectRegistry.TRUE_INVISIBILITY, 100, 0, false, false, true));
 
+
+        playerMagicData.resetAdditionalCastData();
 
         super.onCast(level, spellLevel, entity, castSource, playerMagicData);
     }


### PR DESCRIPTION
### Contributor License Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [x] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.


## Summary
- guard Blood Step's additional cast data lookup so stale targeting data is not cast to TeleportData
- clear additional cast data after Blood Step resolves, matching other teleport-style spells

## Crash fixed
Server crash on 1.21.1-3.15.6:
```
java.lang.ClassCastException: class io.redspace.ironsspellbooks.capabilities.magic.TargetEntityCastData cannot be cast to class io.redspace.ironsspellbooks.spells.ender.TeleportSpell
    at io.redspace.ironsspellbooks.spells.blood.BloodStepSpell.onCast(BloodStepSpell.java:98)
```

## Testing
- JAVA_HOME=/usr/lib/jvm/java-21-temurin-jdk ./gradlew clean build