### PR TITLE
Improve Pocket Dimension Logic

### DIFF
--- a/LATEST_CHANGES.MD
+++ b/LATEST_CHANGES.MD
@@ -10,7 +10,10 @@
 
 ### Changes
 - Updated Magic Arrow, Arcane Shackle, and Portal spell icons
-- Pocket Dimensions are now more Configurable
+- Pocket Dimensions
+  - New configs available
+  - Portals now regenerate when broken
+  - You can re-cast the spell to leave your pocket dimension
 - Spell Balance
   - Root Entity now has health, and can be damaged and killed
   - Oakskin Rebalance

--- a/LATEST_CHANGES.MD
+++ b/LATEST_CHANGES.MD
@@ -10,6 +10,7 @@
 
 ### Changes
 - Updated Magic Arrow, Arcane Shackle, and Portal spell icons
+- Pocket Dimensions are now more Configurable
 - Spell Balance
   - Root Entity now has health, and can be damaged and killed
   - Oakskin Rebalance

--- a/LATEST_CHANGES.MD
+++ b/LATEST_CHANGES.MD
@@ -14,6 +14,7 @@
   - New configs available
   - Portals now regenerate when broken
   - You can re-cast the spell to leave your pocket dimension
+  - Voidstone now has an item form
 - Spell Balance
   - Root Entity now has health, and can be damaged and killed
   - Oakskin Rebalance

--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/MagicEvents.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/MagicEvents.java
@@ -1,6 +1,7 @@
 package io.redspace.ironsspellbooks.capabilities.magic;
 
 import io.redspace.ironsspellbooks.IronsSpellbooks;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.event.tick.LevelTickEvent;
 
@@ -28,6 +29,8 @@ public class MagicEvents {
         }
 
         IronsSpellbooks.MAGIC_MANAGER.tick(event.getLevel());
-        PocketDimensionManager.INSTANCE.tick(event.getLevel());
+        if (ServerConfigs.SNAP_TO_POCKET_BOUNDS.get()) {
+            PocketDimensionManager.INSTANCE.tick(event.getLevel());
+        }
     }
 }

--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
@@ -40,6 +40,7 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
     private static final String INT_ID_KEY = "pocket_id";
     private static final String ID_MAP_KEY = "ids";
     private static final String RETURN_POS_KEY = "returns";
+    private static final String SAVED_SPACING_KEY = "spacing";
 
     public static final PocketDimensionManager INSTANCE = new PocketDimensionManager();
 
@@ -50,6 +51,7 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
 
     private final Object2IntMap<UUID> ids = new Object2IntOpenHashMap<>();
     private final ArrayList<PortalPos> returnPositions = new ArrayList<PortalPos>();
+    private int pocketSpacing = 256;
 
     @Override
     public @UnknownNullability CompoundTag serializeNBT(HolderLookup.Provider provider) {
@@ -67,12 +69,14 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
             returnEntries.add(NBT.writePortalPos(returnPos));
         }
         compoundTag.put(RETURN_POS_KEY, returnEntries);
+        compoundTag.putInt(SAVED_SPACING_KEY, pocketSpacing);
         return compoundTag;
     }
 
     @Override
     public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
-        int highestId = 0;
+        pocketSpacing = nbt.getInt(SAVED_SPACING_KEY);
+        int highestId = -1;
         ListTag idEntries = nbt.getList(ID_MAP_KEY, 10);
         for (Tag tag : idEntries) {
             try {
@@ -99,6 +103,14 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         for (int i = returnPositions.size(); i <= highestId; i++) {
             returnPositions.add(null);
         }
+        if (pocketSpacing == 0) {
+            if (highestId > -1) { pocketSpacing = 256; } // Worlds with preexisting pockets should go to previous versions' 256
+            else { pocketSpacing = ServerConfigs.POCKET_SPACING.get(); } // New worlds or ones without pockets should use config value
+        }
+    }
+
+    public int getPocketSpacing() {
+        return pocketSpacing;
     }
 
     public boolean hasId(UUID uuid) {
@@ -121,7 +133,7 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
     }
 
     private BlockPos structurePosForId(int pocketDimensionId) {
-        return BlockPos.containing(0, 0, ServerConfigs.POCKET_SPACING.get() * pocketDimensionId);
+        return BlockPos.containing(0, 0, getPocketSpacing() * pocketDimensionId);
     }
 
     public BlockPos structurePosForPlayer(Player player) {
@@ -186,8 +198,8 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         if (serverLevel.getGameTime() % 100 == 0) {
             serverLevel.players().forEach(player -> {
                 if (!player.isCreative() && !player.isSpectator()) {
-                    int pocketX = (int) (player.getX() / ServerConfigs.POCKET_SPACING.get()) * ServerConfigs.POCKET_SPACING.get();
-                    int pocketZ = (int) (player.getZ() / ServerConfigs.POCKET_SPACING.get()) * ServerConfigs.POCKET_SPACING.get();
+                    int pocketX = (int) (player.getX() / getPocketSpacing()) * getPocketSpacing();
+                    int pocketZ = (int) (player.getZ() / getPocketSpacing()) * getPocketSpacing();
                     if (player.getX() < pocketX || player.getX() > pocketX + 16
                             || player.getZ() < pocketZ || player.getZ() > pocketZ + 16) {
                         // snap player back into bounds

--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
@@ -3,6 +3,7 @@ package io.redspace.ironsspellbooks.capabilities.magic;
 import io.redspace.ironsspellbooks.IronsSpellbooks;
 import io.redspace.ironsspellbooks.data.IronsDataStorage;
 import io.redspace.ironsspellbooks.registries.BlockRegistry;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
 import io.redspace.ironsspellbooks.worldgen.ClearPortalFrameDataProcessor;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -31,7 +32,6 @@ import java.util.UUID;
 public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
     public static final ResourceKey<Level> POCKET_DIMENSION = ResourceKey.create(Registries.DIMENSION, IronsSpellbooks.id("pocket_dimension"));
     public static final ResourceLocation POCKET_ROOM_STRUCTURE = IronsSpellbooks.id("pocket_room");
-    public static final int POCKET_SPACING = 256;
 
     private static final String UUID_KEY = "uuid";
     private static final String INT_ID_KEY = "pocket_id";
@@ -96,7 +96,7 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
     }
 
     public BlockPos structurePosForId(int pocketDimensionId) {
-        return BlockPos.containing(0, 0, POCKET_SPACING * pocketDimensionId);
+        return BlockPos.containing(0, 0, ServerConfigs.POCKET_SPACING.get() * pocketDimensionId);
     }
 
     public BlockPos structurePosForPlayer(Player player) {
@@ -147,8 +147,8 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         if (serverLevel.getGameTime() % 100 == 0) {
             serverLevel.players().forEach(player -> {
                 if (!player.isCreative() && !player.isSpectator()) {
-                    int pocketX = (int) (player.getX() / PocketDimensionManager.POCKET_SPACING) * PocketDimensionManager.POCKET_SPACING;
-                    int pocketZ = (int) (player.getZ() / PocketDimensionManager.POCKET_SPACING) * PocketDimensionManager.POCKET_SPACING;
+                    int pocketX = (int) (player.getX() / ServerConfigs.POCKET_SPACING.get()) * ServerConfigs.POCKET_SPACING.get();
+                    int pocketZ = (int) (player.getZ() / ServerConfigs.POCKET_SPACING.get()) * ServerConfigs.POCKET_SPACING.get();
                     if (player.getX() < pocketX || player.getX() > pocketX + 16
                             || player.getZ() < pocketZ || player.getZ() > pocketZ + 16) {
                         // snap player back into bounds

--- a/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
+++ b/src/main/java/io/redspace/ironsspellbooks/capabilities/magic/PocketDimensionManager.java
@@ -5,6 +5,8 @@ import io.redspace.ironsspellbooks.data.IronsDataStorage;
 import io.redspace.ironsspellbooks.registries.BlockRegistry;
 import io.redspace.ironsspellbooks.config.ServerConfigs;
 import io.redspace.ironsspellbooks.worldgen.ClearPortalFrameDataProcessor;
+import io.redspace.ironsspellbooks.entity.spells.portal.PortalPos;
+import io.redspace.ironsspellbooks.util.NBT;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.core.BlockPos;
@@ -28,6 +30,7 @@ import net.neoforged.neoforge.common.util.INBTSerializable;
 import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.UUID;
+import java.util.ArrayList;
 
 public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
     public static final ResourceKey<Level> POCKET_DIMENSION = ResourceKey.create(Registries.DIMENSION, IronsSpellbooks.id("pocket_dimension"));
@@ -36,7 +39,7 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
     private static final String UUID_KEY = "uuid";
     private static final String INT_ID_KEY = "pocket_id";
     private static final String ID_MAP_KEY = "ids";
-    private static final String NEXT_ID_KEY = "next_id";
+    private static final String RETURN_POS_KEY = "returns";
 
     public static final PocketDimensionManager INSTANCE = new PocketDimensionManager();
 
@@ -45,62 +48,88 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         IronsDataStorage.INSTANCE.setDirty();
     }
 
-    private int nextId;
-    //todo: should we store block position as well? would give freedom to change id hasher in the future
     private final Object2IntMap<UUID> ids = new Object2IntOpenHashMap<>();
+    private final ArrayList<PortalPos> returnPositions = new ArrayList<PortalPos>();
 
     @Override
     public @UnknownNullability CompoundTag serializeNBT(HolderLookup.Provider provider) {
         CompoundTag compoundTag = new CompoundTag();
-        ListTag entries = new ListTag();
+        ListTag idEntries = new ListTag();
         for (var entry : ids.object2IntEntrySet()) {
             CompoundTag tagEntry = new CompoundTag();
             tagEntry.putUUID(UUID_KEY, entry.getKey());
             tagEntry.putInt(INT_ID_KEY, entry.getIntValue());
-            entries.add(tagEntry);
+            idEntries.add(tagEntry);
         }
-        compoundTag.put(ID_MAP_KEY, entries);
-        compoundTag.putInt(NEXT_ID_KEY, nextId);
+        compoundTag.put(ID_MAP_KEY, idEntries);
+        ListTag returnEntries = new ListTag();
+        for (var returnPos : returnPositions) {
+            returnEntries.add(NBT.writePortalPos(returnPos));
+        }
+        compoundTag.put(RETURN_POS_KEY, returnEntries);
         return compoundTag;
     }
 
     @Override
     public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
-        ListTag entries = nbt.getList(ID_MAP_KEY, 10);
-        int nextId = nbt.getInt(NEXT_ID_KEY);
-        for (Tag tag : entries) {
+        int highestId = 0;
+        ListTag idEntries = nbt.getList(ID_MAP_KEY, 10);
+        for (Tag tag : idEntries) {
             try {
                 CompoundTag compoundTag = (CompoundTag) tag;
                 UUID uuid = compoundTag.getUUID(UUID_KEY);
                 int pocketId = compoundTag.getInt(INT_ID_KEY);
+                if (highestId < pocketId) { highestId = pocketId; }
                 ids.put(uuid, pocketId);
             } catch (Exception e) {
                 IronsSpellbooks.LOGGER.error("Failed to parse PocketDimensionManager id entry: {}: {}", tag, e.getMessage());
             }
         }
-        this.nextId = nextId;
+        returnPositions.ensureCapacity(highestId+1);
+        ListTag returnEntries = nbt.getList(RETURN_POS_KEY, 10);
+        for (Tag tag : returnEntries) {
+            try {
+                CompoundTag compoundTag = (CompoundTag) tag;
+                returnPositions.add(NBT.readPortalPos(compoundTag));
+            } catch (Exception e) {
+                IronsSpellbooks.LOGGER.error("Failed to parse PocketDimensionManager position: {}: {}", tag, e.getMessage());
+            }
+        }
+        // Place extra null values to make sure there are return slots for each id
+        for (int i = returnPositions.size(); i <= highestId; i++) {
+            returnPositions.add(null);
+        }
     }
 
-    //todo: should this be the trigger for generating a new platform? getOrCreateRoomId? i think so
-    public int idFor(UUID uuid) {
-        if (!ids.containsKey(uuid)) {
-            ids.put(uuid, nextId);
-            nextId++;
-            IronsDataStorage.INSTANCE.setDirty();
+    public boolean hasId(UUID uuid) {
+        return ids.containsKey(uuid);
+    }
+
+    public boolean hasId(Player player) {
+        return hasId(player.getUUID());
+    }
+
+    private int idFor(UUID uuid) {
+        if (!hasId(uuid)) {
+            return -1;
         }
         return ids.getInt(uuid);
     }
 
-    public int idFor(Player player) {
+    private int idFor(Player player) {
         return idFor(player.getUUID());
     }
 
-    public BlockPos structurePosForId(int pocketDimensionId) {
+    private BlockPos structurePosForId(int pocketDimensionId) {
         return BlockPos.containing(0, 0, ServerConfigs.POCKET_SPACING.get() * pocketDimensionId);
     }
 
     public BlockPos structurePosForPlayer(Player player) {
         return structurePosForId(idFor(player));
+    }
+
+    public PortalPos returnPosForPlayer(Player player) {
+        return returnPositions.get(idFor(player));
     }
 
     public BlockPos findPortalForStructure(ServerLevel pocketDimension, BlockPos blockPos) {
@@ -122,12 +151,18 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
         return defaultPos;
     }
 
-    public boolean maybeGeneratePocketRoom(ServerPlayer player) {
-        var serverLevel = player.serverLevel();
-        var structurePos = structurePosForPlayer(player);
-        var pocketLevel = serverLevel.getServer().getLevel(POCKET_DIMENSION);
-        BlockState blockState = pocketLevel.getBlockState(structurePos);
-        if (blockState.isAir() && !blockState.is(Blocks.BARRIER)) {
+    public boolean generatePocketIfUnassigned(ServerPlayer player) {
+        UUID playerUUId = player.getUUID();
+        if (!hasId(playerUUId))
+        {
+            // Assign new ID
+            ids.put(playerUUId, returnPositions.size());
+            returnPositions.add(PortalPos.of(player.level.dimension(), player.position(), player.getYRot()));
+            var structurePos = structurePosForId(returnPositions.size());
+            IronsDataStorage.INSTANCE.setDirty();
+            // Create new pocket dimension
+            var pocketLevel = player.serverLevel().getServer().getLevel(POCKET_DIMENSION);
+            BlockState blockState = pocketLevel.getBlockState(structurePos);
             var structureTemplateManager = pocketLevel.getStructureManager();
             var structureTemplate = structureTemplateManager.getOrCreate(POCKET_ROOM_STRUCTURE);
             var placementSettings = (new StructurePlaceSettings()).setMirror(Mirror.NONE).setRotation(Rotation.NONE).setIgnoreEntities(true).addProcessor(new ClearPortalFrameDataProcessor());
@@ -135,6 +170,10 @@ public class PocketDimensionManager implements INBTSerializable<CompoundTag> {
             return true;
         }
         return false;
+    }
+
+    public void updateReturn(ServerPlayer player) {
+        returnPositions.set(idFor(player), PortalPos.of(player.level.dimension(), player.position(), player.getYRot()));
     }
 
     public void tick(Level level) {

--- a/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
+++ b/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
@@ -8,9 +8,11 @@ import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.SpellRarity;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 import java.util.*;
@@ -51,6 +53,10 @@ public class ServerConfigs {
 
     public static final ModConfigSpec.ConfigValue<Boolean> PORTAL_FRAME_RESTRICT_DYE;
     public static final ModConfigSpec.ConfigValue<Boolean> PORTAL_FRAME_RESTRICT_BREAKING;
+    
+    public static final ModConfigSpec.ConfigValue<Boolean> SNAP_TO_POCKET_BOUNDS;
+    public static final ModConfigSpec.ConfigValue<Integer> POCKET_SPACING;
+    private static final ModConfigSpec.ConfigValue<List<? extends String>> POCKET_INACCESSIBLE;
 
 
     public static final ModConfigSpec.ConfigValue<Double> TYROS_ADDITIONAL_HEALTH;
@@ -67,6 +73,7 @@ public class ServerConfigs {
     public static final Set<Item> UPGRADE_BLACKLIST_ITEMS = new HashSet<>();
     public static final Set<Item> IMBUE_WHITELIST_ITEMS = new HashSet<>();
     public static final Set<Item> IMBUE_BLACKLIST_ITEMS = new HashSet<>();
+    public static final Set<ResourceKey<Level>> POCKET_INACCESSIBLE_DIMENSIONS = new HashSet<>();
 
     //https://forge.gemwire.uk/wiki/Configs
 
@@ -169,6 +176,17 @@ public class ServerConfigs {
         }
 
         {
+            BUILDER.push("Pocket Dimensions");
+            BUILDER.comment("Whether players who leave the confines of their Pocket Dimension are teleported back. Default: true");
+            SNAP_TO_POCKET_BOUNDS = BUILDER.define("snapToPocketBounds", true);
+            BUILDER.comment("How many blocks apart each player's Pocket Dimensions will be from eachother. Default: 256");
+            POCKET_SPACING = BUILDER.define("pocketSpacing", 256);
+            BUILDER.comment("Dimensions where the Pocket Dimension cannot be accessed. Add a dimension's id to prevent the spell from being cast there, ex: \"minecraft:the_end\"");
+            POCKET_INACCESSIBLE = BUILDER.defineListAllowEmpty("pocketInaccessibleDimensions", ArrayList::new, (string) -> true);
+            BUILDER.pop();
+        }
+
+        {
             BUILDER.push("Boss Config");
             BUILDER.comment("Configure Boss Stats");
             {
@@ -215,6 +233,7 @@ public class ServerConfigs {
         cacheItemList(UPGRADE_BLACKLIST.get(), UPGRADE_BLACKLIST_ITEMS);
         cacheItemList(IMBUE_WHITELIST.get(), IMBUE_WHITELIST_ITEMS);
         cacheItemList(IMBUE_BLACKLIST.get(), IMBUE_BLACKLIST_ITEMS);
+        cacheDimensionList(POCKET_INACCESSIBLE.get(), POCKET_INACCESSIBLE_DIMENSIONS);
     }
 
     private static void cacheItemList(List<? extends String> ids, Set<Item> output) {
@@ -234,6 +253,17 @@ public class ServerConfigs {
                 }
             } catch (Exception e) {
                 IronsSpellbooks.LOGGER.warn("Unable to validate item config: {}", e.getMessage());
+            }
+        }
+    }
+
+    private static void cacheDimensionList(List<? extends String> ids, Set<ResourceKey<Level>> output) {
+        output.clear();
+        for (String name : ids) {
+            try {
+                output.add(ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(name)));
+            } catch (Exception e) {
+                IronsSpellbooks.LOGGER.warn("Unable to validate dimension config: {}", e.getMessage());
             }
         }
     }

--- a/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
+++ b/src/main/java/io/redspace/ironsspellbooks/config/ServerConfigs.java
@@ -179,7 +179,7 @@ public class ServerConfigs {
             BUILDER.push("Pocket Dimensions");
             BUILDER.comment("Whether players who leave the confines of their Pocket Dimension are teleported back. Default: true");
             SNAP_TO_POCKET_BOUNDS = BUILDER.define("snapToPocketBounds", true);
-            BUILDER.comment("How many blocks apart each player's Pocket Dimensions will be from eachother. Default: 256");
+            BUILDER.comment("How many blocks apart each player's Pocket Dimensions will be from eachother. Doesn't update existing worlds. Default: 256");
             POCKET_SPACING = BUILDER.define("pocketSpacing", 256);
             BUILDER.comment("Dimensions where the Pocket Dimension cannot be accessed. Add a dimension's id to prevent the spell from being cast there, ex: \"minecraft:the_end\"");
             POCKET_INACCESSIBLE = BUILDER.defineListAllowEmpty("pocketInaccessibleDimensions", ArrayList::new, (string) -> true);

--- a/src/main/java/io/redspace/ironsspellbooks/registries/ItemRegistry.java
+++ b/src/main/java/io/redspace/ironsspellbooks/registries/ItemRegistry.java
@@ -399,6 +399,8 @@ public class ItemRegistry {
             (properties) -> new BlockItem(BlockRegistry.FIREFLY_JAR.get(), new Item.Properties()));
     public static final DeferredHolder<Item, Item> PORTAL_FRAME_ITEM = registerItem("portal_frame",
             (properties) -> new PortalFrameBlockItem(new Item.Properties().fireResistant().rarity(Rarity.RARE)));
+    public static final DeferredHolder<Item, Item> VOIDSTONE_ITEM = registerItem("voidstone",
+            (properties) -> new BlockItem(BlockRegistry.VOIDSTONE.get(), new Item.Properties()));
     public static final DeferredHolder<Item, Item> BRAZIER_ITEM = registerItem("brazier",
             (properties) -> new BlockItem(BlockRegistry.BRAZIER_FIRE.get(), new Item.Properties()));
     public static final DeferredHolder<Item, Item> SOUL_BRAZIER_ITEM = registerItem("brazier_soul",

--- a/src/main/java/io/redspace/ironsspellbooks/render/PocketDimensionEffects.java
+++ b/src/main/java/io/redspace/ironsspellbooks/render/PocketDimensionEffects.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Axis;
 import io.redspace.ironsspellbooks.IronsSpellbooks;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
 import io.redspace.ironsspellbooks.capabilities.magic.PocketDimensionManager;
 import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -112,7 +113,7 @@ public class PocketDimensionEffects extends DimensionSpecialEffects {
         Vec3 cameraPos = camera.getPosition();
         Matrix4f matrix4f1 = new Matrix4f().rotation(quaternionf).translate((float) -cameraPos.x, (float) -cameraPos.y, (float) -cameraPos.z);
         poseStack.mulPose(matrix4f1);
-        int traversal = (int) (cameraPos.z / PocketDimensionManager.POCKET_SPACING) * PocketDimensionManager.POCKET_SPACING;
+        int traversal = (int) (cameraPos.z / ServerConfigs.POCKET_SPACING.get()) * ServerConfigs.POCKET_SPACING.get();
         float HARDCODE_WIDTH = 7.0f;
         float halfWidth = HARDCODE_WIDTH / 2.0f;
         float HARDCODE_X = 4 + halfWidth;

--- a/src/main/java/io/redspace/ironsspellbooks/render/PocketDimensionEffects.java
+++ b/src/main/java/io/redspace/ironsspellbooks/render/PocketDimensionEffects.java
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Axis;
 import io.redspace.ironsspellbooks.IronsSpellbooks;
-import io.redspace.ironsspellbooks.config.ServerConfigs;
 import io.redspace.ironsspellbooks.capabilities.magic.PocketDimensionManager;
 import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -113,7 +112,7 @@ public class PocketDimensionEffects extends DimensionSpecialEffects {
         Vec3 cameraPos = camera.getPosition();
         Matrix4f matrix4f1 = new Matrix4f().rotation(quaternionf).translate((float) -cameraPos.x, (float) -cameraPos.y, (float) -cameraPos.z);
         poseStack.mulPose(matrix4f1);
-        int traversal = (int) (cameraPos.z / ServerConfigs.POCKET_SPACING.get()) * ServerConfigs.POCKET_SPACING.get();
+        int traversal = (int) (cameraPos.z / PocketDimensionManager.INSTANCE.getPocketSpacing()) * PocketDimensionManager.INSTANCE.getPocketSpacing();
         float HARDCODE_WIDTH = 7.0f;
         float halfWidth = HARDCODE_WIDTH / 2.0f;
         float HARDCODE_X = 4 + halfWidth;

--- a/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/PocketDimensionSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/PocketDimensionSpell.java
@@ -15,6 +15,7 @@ import io.redspace.ironsspellbooks.entity.spells.portal.PortalData;
 import io.redspace.ironsspellbooks.entity.spells.portal.PortalPos;
 import io.redspace.ironsspellbooks.item.Scroll;
 import io.redspace.ironsspellbooks.registries.SoundRegistry;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
@@ -61,7 +62,7 @@ public class PocketDimensionSpell extends AbstractSpell {
         if (!(entity instanceof ServerPlayer serverPlayer)) {
             return false;
         }
-        if (level.dimension().equals(PocketDimensionManager.POCKET_DIMENSION)) {
+        if (level.dimension().equals(PocketDimensionManager.POCKET_DIMENSION) || ServerConfigs.POCKET_INACCESSIBLE_DIMENSIONS.contains(level.dimension())) {
             serverPlayer.connection.send(new ClientboundSetActionBarTextPacket(Component.translatable("ui.irons_spellbooks.cast_error_dimension").withStyle(ChatFormatting.RED)));
             return false;
         }

--- a/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/PocketDimensionSpell.java
+++ b/src/main/java/io/redspace/ironsspellbooks/spells/eldritch/PocketDimensionSpell.java
@@ -6,6 +6,7 @@ import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.SchoolRegistry;
 import io.redspace.ironsspellbooks.api.spells.*;
 import io.redspace.ironsspellbooks.api.util.AnimationHolder;
+import io.redspace.ironsspellbooks.block.portal_frame.PortalFrameBlock;
 import io.redspace.ironsspellbooks.block.portal_frame.PortalFrameBlockEntity;
 import io.redspace.ironsspellbooks.capabilities.magic.MagicManager;
 import io.redspace.ironsspellbooks.capabilities.magic.PocketDimensionManager;
@@ -14,6 +15,7 @@ import io.redspace.ironsspellbooks.capabilities.magic.SerializedTargetData;
 import io.redspace.ironsspellbooks.entity.spells.portal.PortalData;
 import io.redspace.ironsspellbooks.entity.spells.portal.PortalPos;
 import io.redspace.ironsspellbooks.item.Scroll;
+import io.redspace.ironsspellbooks.registries.BlockRegistry;
 import io.redspace.ironsspellbooks.registries.SoundRegistry;
 import io.redspace.ironsspellbooks.config.ServerConfigs;
 import net.minecraft.ChatFormatting;
@@ -28,6 +30,7 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.portal.DimensionTransition;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,7 +65,10 @@ public class PocketDimensionSpell extends AbstractSpell {
         if (!(entity instanceof ServerPlayer serverPlayer)) {
             return false;
         }
-        if (level.dimension().equals(PocketDimensionManager.POCKET_DIMENSION) || ServerConfigs.POCKET_INACCESSIBLE_DIMENSIONS.contains(level.dimension())) {
+        if (level.dimension().equals(PocketDimensionManager.POCKET_DIMENSION) && !PocketDimensionManager.INSTANCE.hasId(serverPlayer)) {
+            return false;
+        }
+        if (ServerConfigs.POCKET_INACCESSIBLE_DIMENSIONS.contains(level.dimension())) {
             serverPlayer.connection.send(new ClientboundSetActionBarTextPacket(Component.translatable("ui.irons_spellbooks.cast_error_dimension").withStyle(ChatFormatting.RED)));
             return false;
         }
@@ -107,27 +113,50 @@ public class PocketDimensionSpell extends AbstractSpell {
     public void onCast(Level level, int spellLevel, LivingEntity entity, CastSource castSource, MagicData playerMagicData) {
         super.onCast(level, spellLevel, entity, castSource, playerMagicData);
         if (entity instanceof ServerPlayer serverPlayer) {
-            PortalData portalData = new PortalData();
-            portalData.setPortalDuration(20 * 60);
-            portalData.firstPortal(serverPlayer.getUUID(), PortalPos.of(serverPlayer.level.dimension(), serverPlayer.position(), serverPlayer.getYRot()));
-
-            PocketDimensionManager.INSTANCE.maybeGeneratePocketRoom(serverPlayer);
-            BlockPos portalPos = PocketDimensionManager.INSTANCE.findPortalForStructure(serverPlayer.serverLevel(), PocketDimensionManager.INSTANCE.structurePosForPlayer(serverPlayer));
-            ServerLevel pocketLevel = serverPlayer.getServer().getLevel(PocketDimensionManager.POCKET_DIMENSION);
-            var portal = pocketLevel.getBlockEntity(portalPos);
-            if (portal instanceof PortalFrameBlockEntity portalFrameBlockEntity) {
-                Vec3 particlePos = serverPlayer.getBoundingBox().getCenter();
-                MagicManager.spawnParticles(level, ParticleTypes.SMOKE, particlePos.x, particlePos.y, particlePos.z, 100, 0.1, 0.2, 0.1, 0.1, false);
-
-                var uuid = portalFrameBlockEntity.getUUID();
-                portalData.secondPortal(uuid, PortalPos.of(PocketDimensionManager.POCKET_DIMENSION, portalPos.getBottomCenter(), 180));
-                PortalManager.INSTANCE.addPortalData(uuid, portalData);
-                portalFrameBlockEntity.setChanged();
-                PortalManager.INSTANCE.addDirectPortalCooldown(serverPlayer, uuid); // Manually add cooldown as if the player used the portal to help prevent immediately teleporting back
+            Vec3 particlePos = serverPlayer.getBoundingBox().getCenter();
+            MagicManager.spawnParticles(level, ParticleTypes.SMOKE, particlePos.x, particlePos.y, particlePos.z, 100, 0.1, 0.2, 0.1, 0.1, false);
+            // Pull player out of pocket dimension
+            if (level.dimension().equals(PocketDimensionManager.POCKET_DIMENSION) && PocketDimensionManager.INSTANCE.hasId(serverPlayer)) {
+                // Fetch return position and put them there
+                PortalPos returnTo = PocketDimensionManager.INSTANCE.returnPosForPlayer(serverPlayer);
+                if (returnTo != null)
+                {
+                    Scroll.attemptRemoveScrollAfterCast(serverPlayer); // Manually call this because this serverplayer will be removed from the level after the spellcast
+                    PocketDimensionManager.INSTANCE.updateReturn(serverPlayer);
+                    serverPlayer.stopRiding();
+                    serverPlayer.changeDimension(new DimensionTransition(serverPlayer.getServer().getLevel(returnTo.dimension()), returnTo.pos(), Vec3.ZERO, returnTo.rotation(), serverPlayer.getXRot(), DimensionTransition.DO_NOTHING));
+                }
+            }
+            // Place player in pocket dimension
+            else {
+                PortalData portalData = new PortalData();
+                portalData.setPortalDuration(20 * 60);
+                portalData.firstPortal(serverPlayer.getUUID(), PortalPos.of(serverPlayer.level.dimension(), serverPlayer.position(), serverPlayer.getYRot()));
+                // Generate a pocket and get the portal
+                PocketDimensionManager.INSTANCE.generatePocketIfUnassigned(serverPlayer);
+                BlockPos portalPos = PocketDimensionManager.INSTANCE.findPortalForStructure(serverPlayer.serverLevel(), PocketDimensionManager.INSTANCE.structurePosForPlayer(serverPlayer));
+                ServerLevel pocketLevel = serverPlayer.getServer().getLevel(PocketDimensionManager.POCKET_DIMENSION);
+                var portalChunk = pocketLevel.getChunk(portalPos);
+                var portal = portalChunk.getBlockEntity(portalPos);
+                // If no portal is found, make a new one
+                if (!(portal instanceof PortalFrameBlockEntity portalFrameBlockEntity)) {
+                    pocketLevel.setBlockAndUpdate(portalPos, BlockRegistry.POCKET_PORTAL_FRAME.get().defaultBlockState().setValue(PortalFrameBlock.HALF, DoubleBlockHalf.LOWER));
+                    pocketLevel.setBlockAndUpdate(portalPos.above(), BlockRegistry.POCKET_PORTAL_FRAME.get().defaultBlockState().setValue(PortalFrameBlock.HALF, DoubleBlockHalf.UPPER));
+                    portal = portalChunk.getBlockEntity(portalPos);
+                }
+                // Target portal if the new one is found
+                if (portal instanceof PortalFrameBlockEntity portalFrameBlockEntity) {
+                    var uuid = portalFrameBlockEntity.getUUID();
+                    portalData.secondPortal(uuid, PortalPos.of(PocketDimensionManager.POCKET_DIMENSION, portalPos.getBottomCenter(), 180));
+                    PortalManager.INSTANCE.addPortalData(uuid, portalData);
+                    portalFrameBlockEntity.setChanged();
+                    PortalManager.INSTANCE.addDirectPortalCooldown(serverPlayer, uuid); // Manually add cooldown as if the player used the portal to help prevent immediately teleporting back
+                }
+                // Regardless of if a portal is present, update their return destination and send player to their pocket dimension
                 Scroll.attemptRemoveScrollAfterCast(serverPlayer); // Manually call this because this serverplayer will be removed from the level after the spellcast
+                PocketDimensionManager.INSTANCE.updateReturn(serverPlayer);
                 serverPlayer.stopRiding();
-                serverPlayer.changeDimension(new DimensionTransition(pocketLevel, portalData.globalPos2.pos(), Vec3.ZERO, portalData.globalPos2.rotation(), serverPlayer.getXRot(), DimensionTransition.DO_NOTHING));
-
+                serverPlayer.changeDimension(new DimensionTransition(pocketLevel, portalPos.getBottomCenter(), Vec3.ZERO, 180, serverPlayer.getXRot(), DimensionTransition.DO_NOTHING));
             }
         }
     }

--- a/src/main/resources/assets/irons_spellbooks/models/item/voidstone.json
+++ b/src/main/resources/assets/irons_spellbooks/models/item/voidstone.json
@@ -1,0 +1,95 @@
+{
+	"format_version": "1.21.11",
+	"credit": "Made with Blockbench",
+	"parent": "minecraft:block/cube",
+	"render_type": "minecraft:cutout",
+	"textures": {
+		"all": "irons_spellbooks:block/voidstone",
+		"0": "irons_spellbooks:block/voidstone_trim",
+		"1": "irons_spellbooks:block/voidstone_trim_corner",
+		"particle": "irons_spellbooks:block/voidstone"
+	},
+	"elements": [
+		{
+			"name": "block",
+			"from": [0, 0, 0],
+			"to": [16, 16, 16],
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#all"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#all"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#all"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#all"},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#all"},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#all"}
+			}
+		},
+		{
+			"name": "sides",
+			"from": [-0.001, 0.001, -0.001],
+			"to": [16.001, 16.001, 16.001],
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#0"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#0"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#0"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#0"},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#0"}
+			}
+		},
+		{
+			"name": "trim2",
+			"from": [0, 16.0015, 0],
+			"to": [16, 16.0015, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "trim3",
+			"from": [0, 16.001, 0],
+			"to": [16, 16.001, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"name": "trim4",
+			"from": [0, 16.0015, 0],
+			"to": [16, 16.0015, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#0"}
+			}
+		},
+		{
+			"name": "corner1",
+			"from": [0, 16.002, 0],
+			"to": [16, 16.002, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "texture": "#1"}
+			}
+		},
+		{
+			"name": "corner2",
+			"from": [0, 16.002, 0],
+			"to": [16, 16.002, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"name": "corner3",
+			"from": [0, 16.002, 0],
+			"to": [16, 16.002, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#1"}
+			}
+		},
+		{
+			"name": "corner4",
+			"from": [0, 16.002, 0],
+			"to": [16, 16.002, 16],
+			"faces": {
+				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#1"}
+			}
+		}
+	]
+}


### PR DESCRIPTION
- This fixes #959 by making players able to re-cast the Pocket Dimension spell in order to leave their pocket dimension, and regenerating the portal if it is missing. This is was done by creating a new registry of return locations matched to Pocket Dimension IDs, bypassing the need for the Portal Block Entity to teleport into the Pocket Dimension.
- This fixes #1120 by adding a Voidstone item - it shows up in-game as Voidstone with all 4 directions trimmed.
<img width="180" height="224" alt="image" src="https://github.com/user-attachments/assets/b7e6e230-bfbe-4b8d-98df-0242341a32ca" /> *Looks oddly like a crafting table!*
- This does not fix #1180, but it shouldn't happen in the future since the seperate `nextId` that was likely responsible has been replaced with reading the length of the registries, and there are additional checks when deserializing to make sure that length is correct.
- This fixes #1209 (if it wasn't considered a duplicate) by reading and thus loading the chunk to access the Pocket Dimension (fixes it being inaccessible when DimThreads is installed), and by regenerating the portal if it's missing, and also by always allowing teleports in and out even if both of those fail.
- This fixes an unindexed issue - breaking the bottom northwestern barrier of a Pocket Dimension would reset it and all its contents - by changing the dimensions to only generate once when a player is initially assigned one.
- Additionally, this adds 3 new config options:
   - You can disable snapping back to your Pocket Dimension when you go out of bounds
   - You can change the distance between Pocket Dimensions, though the value is cached for worlds that have preexisting pockets as to not break their generation
   - You can assign what dimensions the Pocket Dimension spell cannot be cast in, and putting `irons_spellbooks:pocket_dimension` in the list should remove the ability to re-cast and leave your pocket dimension (restoring old behaviour)

I'd highly recommend testing this yourself! Even though I never encountered any issues, I wouldn't be surprised if the changes I made break something.

**Contributor License Agreement** - [Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.
