### PR TITLE
fix c2me crash by passing random to loot table generation

### DIFF
--- a/src/main/java/io/redspace/ironsspellbooks/player/AdditionalWanderingTrades.java
+++ b/src/main/java/io/redspace/ironsspellbooks/player/AdditionalWanderingTrades.java
@@ -268,7 +268,7 @@ public class AdditionalWanderingTrades {
                 if (!trader.level.isClientSide) {
                     LootTable loottable = trader.level.getServer().reloadableRegistries().getLootTable(ResourceKey.create(Registries.LOOT_TABLE, IronsSpellbooks.id("magic_items/basic_curios")));
                     var context = new LootParams.Builder((ServerLevel) trader.level).create(LootContextParamSets.EMPTY);
-                    var items = loottable.getRandomItems(context);
+                    var items = loottable.getRandomItems(context, random);
                     if (!items.isEmpty()) {
                         ItemStack forSale = items.get(0);
                         var cost = new ItemCost(Items.EMERALD, 64);
@@ -286,7 +286,7 @@ public class AdditionalWanderingTrades {
                 if (!trader.level.isClientSide) {
                     LootTable loottable = trader.level.getServer().reloadableRegistries().getLootTable(ResourceKey.create(Registries.LOOT_TABLE, IronsSpellbooks.id("magic_items/scroll_pouch")));
                     var context = new LootParams.Builder((ServerLevel) trader.level).create(LootContextParamSets.EMPTY);
-                    var items = loottable.getRandomItems(context);
+                    var items = loottable.getRandomItems(context, random);
                     if (!items.isEmpty()) {
                         int quality = 0;
                         for (ItemStack stack : items) {


### PR DESCRIPTION
### Contributor License Agreement
[Full CLA](https://github.com/iron431/Irons-Spells-n-Spellbooks/blob/1.19.2/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agree to the CLA for Iron's Spells and Spellbooks which allows me to retain my ownership in the code submitted while granting the repository owner legal rights to use my contribution.

This fixes a chunk generation issue caused when the following mods are installed:
- Moog's Voyager Structues v5.1.1
- Concurrent Chunk Management Engine (C2ME) v0.4.0-alpha.0.120+1
- Iron's Spells 'n Spellbooks v1.21.1-3.16.3

Here a thread trace of said issue
https://mclo.gs/dWFjiSO